### PR TITLE
Add initial drafts for APTITUDE RFC-01 and RFC-02

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ venv/
 build/
 site/
 .cache/
+
+# Local draft notes
+docs/horizontal-RFCs/RFC002-ISO18013-7-alignment.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,5 +76,8 @@
         "WSCA",
         "WSCD",
         "xelatex"
-    ]
+    ],
+    "chat.tools.terminal.autoApprove": {
+        "pip": true
+    }
 }

--- a/docs/glossary-definitions.md
+++ b/docs/glossary-definitions.md
@@ -69,7 +69,7 @@ components:Wallet Instance Attestation (WIA)
 components:Keystore
 : Hardware-backed repository for generating, storing, and using non-critical cryptographic assets.
 
-component:Qualified Trust Service Provider (QTSP)
+components:Qualified Trust Service Provider (QTSP)
 : A qualified trust services provider authorised, among other things, to issue QEAA under eIDAS/eIDAS2.
 
 credentials:Person Identification Data (PID)
@@ -176,59 +176,30 @@ credentials:HAIP (High Assurance Interoperability Profile)
 
 credentials:IANA JWT Claims (Internet Assigned Numbers Authority JSON Web Token Claims)
 : IANA registry of standard JWT claim names.
+
 protocols:Credential Offer
 : Data structure created by a Credential Issuer to initiate issuer-initiated issuance, containing grant information and credential configuration references.
 
-credentials:mVC (mobile Vehicle Certificate
-: The family of mobile vehicle certificates defined in ISO/IEC 7367‑2, on which the EU‑mVRC is profiled.
+protocols:Proof-of-possession
+: Cryptographic proof demonstrating control of a private key, produced by signing a server-issued challenge; used to bind credentials and tokens to a Wallet key.
 
-credentials:mTR (mobile Technical Report)
-: A mobile roadworthiness/inspection report (companion to mVRC/mDL) per ISO/IEC 7367‑3.
+protocols:Key binding
+: Cryptographic binding of a credential to a specific key pair held by the Wallet, ensuring only the key holder can present that credential.
 
-credentilas:mDL (mobile Driving Licence)
-: The mobile driving licence per ISO/IEC 18013‑5/-7; used alongside mVRC and mTR in the EUDI Wallet.
+protocols:Device binding
+: Association of a credential or session with a specific device, establishing that the credential can only be used from the bound device.
 
-credentials:MSO (Mobile Security Object)
-: A security object carrying metadata and the issuer’s signature over data elements in mdoc/mDL/mVRC.
+protocols:Nonce
+: A single-use, unpredictable value issued by a server to prevent replay attacks; Wallets must include it verbatim in proofs or responses.
 
-credentials:mdoc
-: The generic model and protocols for mobile documents per ISO/IEC 23220‑4.
+protocols:PKCE
+: Proof Key for Code Exchange (RFC 7636). An extension to the OAuth 2.0 authorization code flow that prevents authorization-code interception attacks using a code verifier and code challenge.
 
-credentials:Proximity flow
-: Short‑range presentation protocol (NFC/BLE/Wi‑Fi Aware) per ISO/IEC 18013‑5/‑7.
+protocols:DPoP
+: Demonstrating Proof of Possession (RFC 9449). A mechanism that binds access tokens and refresh tokens to a client key pair, preventing token replay by third parties.
 
-credentials:Remote flow
-: Remote presentation protocol (same‑device or cross‑device).
+protocols:Request Object
+: A JWT carrying OAuth 2.0 authorization request parameters as defined in RFC 9101, which may be passed by value or by reference (JAR); used in OID4VP to convey the Verifier's presentation request.
 
-credentials:Trust anchor
-: The root of trust (certificates/chain) required to verify an attestation’s signature.
-
-credentials:IACA
-: The issuing authority/CA used in the mDL/mVRC trust infrastructure under ISO (may be shared with mDL or set up separately).
-
-credentials:CBOR (Concise Binary Object Representation)
-: The binary serialisation format used for mdoc transfers.
-
-credentials:CDDL (Concise Data Definition Language)
-: The language to define CBOR structures (e.g., `tstr`, `uint`, `bstr`, `tdate`).
-
-credentials:eCoC (electronic Certificate of Conformity)
-: Manufacturer’s electronic certificate; selected entries are mapped into EU‑mVRC.
-
-credentials:SD‑JWT VC (Selective Disclosure Java Web Token Verifiable Credential)
-: A verifiable credential format based on Selective Disclosure JWT; one of the formats supported in EUDI for some attestations.
-
-credentials:W3C VCDM v2.0 (W3C Verifiable Credentials Data Model v2.0)
-: A family of specifications for VC data models.
-
-credentials:OID4VCI (OpenID for Verifiable Credentials Issuance)
-: OID4VCI is an open standard that defines a secure API for issuing Verifiable Credentials (VCs) to a user's digital wallet.
-
-credentials:OID4VP (OpenID for Verifiable Presentation)
-: OID4VP is a standard that defines how a user presents Verifiable Credentials from their wallet to a verifier.
-
-credentials:HAIP (High Assurance Interoperability Profile)
-: OpenID4VC profile aimed at higher assurance interoperability.
-
-credentials:IANA JWT Claims (Internet Assigned Numbers Authority JSON Web Token Claims)
-: IANA registry of standard JWT claim names.
+protocols:Presentation Request
+: A request from a Verifier, conveyed in a Request Object, that specifies which credentials or attributes the Wallet must present, typically using a Presentation Definition (DIF PE).

--- a/docs/glossary-definitions.md
+++ b/docs/glossary-definitions.md
@@ -18,6 +18,24 @@ roles:(Wallet-) Relying Party
 roles:Access Certificate Authority
 : Provider mandated by a Member State to issue wallet-relying party access certificates.
 
+roles:Holder
+: Natural person or legal representative controlling the Wallet and authorising credential issuance or presentation.
+
+roles:Verifier
+: Entity requesting verifiable presentations, validating the response, and making an authorisation or business decision based on the outcome.
+
+roles:Credential Issuer
+: Entity that decides to issue Verifiable Credentials and operates, or is associated with, the issuance service.
+
+roles:Authorisation Server
+: OAuth 2.0 / OpenID component responsible for authenticating the Holder and issuing tokens authorising access to protected endpoints.
+
+roles:Verifier Backend
+: Server-side component that creates presentation requests, receives presentation responses, validates them, and returns the result to the relying application.
+
+roles:Relying Application
+: User-facing application, service, or workflow in which credential verification is performed.
+
 roles:Holder (W2W)
 : User presenting attributes from their Wallet Unit to another Wallet Unit.
 
@@ -44,6 +62,9 @@ components:Wallet Secure Cryptographic Device (WSCD)
 
 components:Wallet Unit Attestation (WUA)
 : Data object describing Wallet Unit components or enabling their authentication/validation.
+
+components:Wallet Instance Attestation (WIA)
+: Client attestation material presented by a Wallet Instance at the PAR and Token endpoints to authenticate the Wallet during issuance flows.
 
 components:Keystore
 : Hardware-backed repository for generating, storing, and using non-critical cryptographic assets.
@@ -109,6 +130,62 @@ credentials:mTR (mobile Technical Report)
 : A mobile roadworthiness/inspection report (companion to mVRC/mDL) per ISO/IEC 7367‑3.
 
 credentials:mDL (mobile Driving Licence)
+: The mobile driving licence per ISO/IEC 18013‑5/-7; used alongside mVRC and mTR in the EUDI Wallet.
+
+credentials:MSO (Mobile Security Object)
+: A security object carrying metadata and the issuer’s signature over data elements in mdoc/mDL/mVRC.
+
+credentials:mdoc
+: The generic model and protocols for mobile documents per ISO/IEC 23220‑4.
+
+credentials:Proximity flow
+: Short‑range presentation protocol (NFC/BLE/Wi‑Fi Aware) per ISO/IEC 18013‑5/‑7.
+
+credentials:Remote flow
+: Remote presentation protocol (same‑device or cross‑device).
+
+credentials:Trust anchor
+: The root of trust (certificates/chain) required to verify an attestation’s signature.
+
+credentials:IACA
+: The issuing authority/CA used in the mDL/mVRC trust infrastructure under ISO (may be shared with mDL or set up separately).
+
+credentials:CBOR (Concise Binary Object Representation)
+: The binary serialisation format used for mdoc transfers.
+
+credentials:CDDL (Concise Data Definition Language)
+: The language to define CBOR structures (e.g., `tstr`, `uint`, `bstr`, `tdate`).
+
+credentials:eCoC (electronic Certificate of Conformity)
+: Manufacturer’s electronic certificate; selected entries are mapped into EU‑mVRC.
+
+credentials:SD‑JWT VC (Selective Disclosure Java Web Token Verifiable Credential)
+: A verifiable credential format based on Selective Disclosure JWT; one of the formats supported in EUDI for some attestations.
+
+credentials:W3C VCDM v2.0 (W3C Verifiable Credentials Data Model v2.0)
+: A family of specifications for VC data models.
+
+credentials:OID4VCI (OpenID for Verifiable Credentials Issuance)
+: OID4VCI is an open standard that defines a secure API for issuing Verifiable Credentials (VCs) to a user's digital wallet.
+
+credentials:OID4VP (OpenID for Verifiable Presentation)
+: OID4VP is a standard that defines how a user presents Verifiable Credentials from their wallet to a verifier.
+
+credentials:HAIP (High Assurance Interoperability Profile)
+: OpenID4VC profile aimed at higher assurance interoperability.
+
+credentials:IANA JWT Claims (Internet Assigned Numbers Authority JSON Web Token Claims)
+: IANA registry of standard JWT claim names.
+protocols:Credential Offer
+: Data structure created by a Credential Issuer to initiate issuer-initiated issuance, containing grant information and credential configuration references.
+
+credentials:mVC (mobile Vehicle Certificate
+: The family of mobile vehicle certificates defined in ISO/IEC 7367‑2, on which the EU‑mVRC is profiled.
+
+credentials:mTR (mobile Technical Report)
+: A mobile roadworthiness/inspection report (companion to mVRC/mDL) per ISO/IEC 7367‑3.
+
+credentilas:mDL (mobile Driving Licence)
 : The mobile driving licence per ISO/IEC 18013‑5/-7; used alongside mVRC and mTR in the EUDI Wallet.
 
 credentials:MSO (Mobile Security Object)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -13,3 +13,7 @@ This glossary centralizes key terms used across the APTITUDE RFCs.
 ## Credentials
 
 <glossary::credentials|theme=table>
+
+## Protocols
+
+<glossary::protocols|theme=table>

--- a/docs/horizontal-RFCs/RFC001.md
+++ b/docs/horizontal-RFCs/RFC001.md
@@ -1,0 +1,917 @@
+# **APTITUDE RFC-01 Credential Issuance Profile**
+
+Version 0.1 (Draft)
+
+## **Authors**
+
+- Nikos Triantafyllou, University of the Aegean
+
+## **Reviewers**
+
+1. Degani Giancarlo, Infocert
+2. Andreea Prian, IDAKTO
+3. Leonardo Pio Palumbo, ipzs
+4. Leone Riello, Infocert
+5. George Fourtounis, GRNET
+
+## **Table of Contents**
+
+- [1. Introduction](#1-introduction)
+- [2. Scope](#2-scope)
+  - [2.1 Out of Scope](#21-out-of-scope)
+- [3. Normative Language](#3-normative-language)
+- [4. Roles and Components](#4-roles-and-components)
+- [5. Protocol Overview](#5-protocol-overview)
+  - [5.1 Credential Format Baseline](#51-credential-format-baseline)
+  - [5.2 Pilot-specific extensions](#52-pilot-specific-extensions)
+- [6. High-level Flows](#6-high-level-flows)
+  - [6.1 Wallet-initiated Issuance Flow](#61-wallet-initiated-issuance-flow)
+    - [6.1.1 Configuration and discovery](#611-configuration-and-discovery)
+    - [6.1.2 User selects credential](#612-user-selects-credential)
+    - [6.1.3 Pushed Authorisation Request (PAR)](#613-pushed-authorisation-request-par)
+    - [6.1.4 User authorisation](#614-user-authorisation)
+    - [6.1.5 Token request](#615-token-request)
+    - [6.1.6 Credential request](#616-credential-request)
+    - [6.1.7 Storage](#617-storage)
+  - [6.2 Issuer-initiated Issuance via Credential Offer](#62-issuer-initiated-issuance-via-credential-offer)
+    - [6.2.1 Issuance decision](#621-issuance-decision)
+    - [6.2.2 Credential Offer creation](#622-credential-offer-creation)
+    - [6.2.3 Credential Offer delivery and Wallet invocation](#623-credential-offer-delivery-and-wallet-invocation)
+    - [6.2.4 Wallet processes the offer](#624-wallet-processes-the-offer)
+    - [6.2.5 Authorisation Code Flow variant](#625-authorisation-code-flow-variant)
+    - [6.2.6 Pre-Authorised Code Flow variant](#626-pre-authorised-code-flow-variant)
+    - [6.2.7 Credential request](#627-credential-request)
+    - [6.2.8 Deferred issuance continuation](#628-deferred-issuance-continuation)
+  - [6.3 Deferred Credential Request](#63-deferred-credential-request)
+- [7. Normative Requirements](#7-normative-requirements)
+  - [7.1 Common requirements (Wallet and Issuer)](#71-common-requirements-wallet-and-issuer)
+  - [7.2 Credential Offer](#72-credential-offer)
+  - [7.3 Authorisation Endpoint and PAR](#73-authorisation-endpoint-and-par)
+  - [7.4 Token Endpoint and Wallet Attestation](#74-token-endpoint-and-wallet-attestation)
+  - [7.5 Credential Endpoint](#75-credential-endpoint)
+    - [7.5.1 Credential Request using proofs.jwt](#751-credential-request-using-proofsjwt)
+    - [7.5.2 Credential Request using proofs.attestation](#752-credential-request-using-proofsattestation)
+  - [7.6 Deferred Credential Endpoint](#76-deferred-credential-endpoint)
+  - [7.7 Server Metadata](#77-server-metadata)
+- [8. Interface Definitions](#8-interface-definitions)
+  - [8.1 Wallet Invocation Interface](#81-wallet-invocation-interface)
+  - [8.2 Credential Offer Interface](#82-credential-offer-interface)
+  - [8.3 PAR Endpoint](#83-par-endpoint)
+  - [8.4 Token Endpoint](#84-token-endpoint)
+  - [8.5 Credential Endpoint](#85-credential-endpoint)
+  - [8.6 Nonce Endpoint](#86-nonce-endpoint)
+  - [8.7 Notification Interface](#87-notification-interface)
+  - [8.8 Deferred Credential Endpoint](#88-deferred-credential-endpoint)
+  - [8.9 Metadata Endpoints](#89-metadata-endpoints)
+- [9. Conformance](#9-conformance)
+- [10. Conformance Check Catalogue and Deployed Test Matrix](#10-conformance-check-catalogue-and-deployed-test-matrix)
+- [References](#references)
+
+## **1 Introduction**
+
+This document is part of **APTITUDE horizontal interoperability RFC** for credential issuance.
+
+It establishes the baseline, cross-pilot profile to be used by APTITUDE pilots and technical implementations for the issuance of Verifiable Credentials in a consistent and testable manner.
+
+This RFC profiles issuance based on:
+
+- OpenID for Verifiable Credential Issuance (OpenID4VCI) 1.0  
+- OpenID4VC High Assurance Interoperability Profile (HAIP) 1.0
+- ETSI TS 119 472-3
+
+The purpose of this document is to provide:
+
+- a stable starting point for interoperability across APTITUDE pilots;
+- a common baseline for Wallets, Issuers, and <roles:Authorisation Server|Authorisation Servers>;
+- a requirements set that can be translated into **ITB+ conformance test suites**;
+- a basis for pilot-specific issuance profiles that need stricter domain or credential-format constraints.
+
+This specification focuses **only on issuance**. It covers wallet-initiated and issuer-initiated issuance, including both **Authorisation Code Flow** and **Pre-Authorised Code Flow**, together with the metadata, security bindings, and proof mechanisms needed to support interoperable issuance.
+
+This document does **not** define presentation or verifier behavior as such. However, where issuance-side metadata is required so that a Wallet can later enforce issuer-defined disclosure or reuse constraints, this document includes those issuance-side requirements.
+
+---
+
+## **2 Scope**
+
+This specification defines:
+
+- a baseline profile of OpenID4VCI for issuing Verifiable Credentials;
+- requirements for Wallets that request, receive, validate, and store credentials;
+- requirements for <roles:Credential Issuer|Credential Issuers> and their <roles:Authorisation Server|Authorisation Servers>;
+- support for **wallet-initiated issuance** and **issuer-initiated issuance via <protocols:Credential Offer>**;
+- support for both **Authorisation Code** Flow and **Pre-Authorised Code Flow**;
+- the minimum endpoints, metadata, and request-processing rules necessary to enable interoperable issuance;
+- issuance-side requirements for wallet attestation, <protocols:Proof-of-possession|proof-of-possession>, <protocols:Device binding|device binding>, and deferred issuance;
+- conditional notification handling where the selected deployment supports issuance notifications;
+- issuance-side metadata elements needed by the Wallet for later lifecycle or disclosure handling, where such elements are delivered as part of issuance.
+
+This document is intentionally **horizontal** and **cross-pilot**. It does not define credential-specific claim sets, domain schemas, or sector-specific assurance rules, except where a specific issuance profile requires explicit protocol-level constraints.
+
+This document describes:
+
+- issuance protocol flows;
+- baseline security and privacy requirements;
+- interfaces and endpoints, including Wallet invocation, <protocols:Credential Offer>, PAR, Token, Credential, Deferred Credential, <protocols:Nonce>, Notification, and metadata endpoints where applicable;
+- conformance requirements that can be mapped to ITB+ test cases.
+
+### **2.1 Out of Scope**
+
+The following are out of scope for this RFC:
+
+- presentation and verification flows;  
+- verifier requirements;  
+- trust framework governance, federation policy, and trust-list operations, except where issuance processing requires validation against such trust material;
+- credential-specific semantic profiles and domain-specific claim definitions;
+- pilot-specific UX constraints;  
+- business, legal, or organisational policy beyond the protocol-visible issuance requirements captured in metadata.
+
+---
+
+## **3 Normative Language**
+
+The key words **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **MAY**, and **OPTIONAL** in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+---
+
+## **4 Roles and Components**
+
+This specification uses the following roles:
+
+- **Wallet Unit / Wallet**: The <components:Wallet Unit>, as defined in the ARF and APTITUDE glossary, including its <components:Wallet Instance|Wallet Instances>, acting on behalf of the <roles:Holder> to request, receive, validate, store, and manage Verifiable Credentials and associated cryptographic material. Where the distinction between Wallet Unit and Wallet Instance is not material, this RFC uses the short term **Wallet**.  
+- **<roles:Holder>**: As defined in the APTITUDE glossary (aligned with the ARF notion of (Wallet) User): the natural person or legal representative controlling the Wallet and authorising credential issuance or presentation.  
+- **<roles:Credential Issuer> (Issuer)**: As defined in the APTITUDE glossary and aligned with the ARF: the entity that decides to issue Verifiable Credentials and operates, or is associated with, the issuance service.  
+- **<roles:Authorisation Server> (AS)**: As defined in the APTITUDE glossary and aligned with the ARF: the OAuth 2.0 / OpenID component responsible for authenticating the <roles:Holder> and issuing tokens authorising access to the Credential and related endpoints.
+
+The <roles:Authorisation Server> MAY be co-located with the <roles:Credential Issuer> or MAY be operated separately.
+
+---
+
+## **5 Protocol Overview**
+
+The APTITUDE issuance baseline is based on **OpenID4VCI 1.0** and constrained by **HAIP 1.0** choices relevant to issuance interoperability. Where required for <components:EUDI Wallet> ecosystem alignment, this profile also incorporates issuance-side requirements drawn from **ETSI TS 119 472-3**.
+
+The profile adopts the following baseline choices:
+
+- support for **Authorisation Code Flow** for issuance interactions requiring <roles:Holder> authentication and authorisation;
+- support for **Pre-Authorised Code Flow** for issuer-initiated issuance scenarios where issuance is initiated through a <protocols:Credential Offer> and the applicable grant is pre-authorised;
+- support for **issuer-initiated issuance via <protocols:Credential Offer>**;
+- support for **wallet-initiated issuance**, where the Wallet selects a credential type or credential configuration and derives the corresponding request parameters from Issuer metadata;
+- use of **Pushed Authorisation Requests (PAR)** for Authorisation Code Flow requests under this profile;
+- use of **<protocols:PKCE> with `S256`** for Authorisation Code Flow;
+- use of **sender-constrained access tokens**, for example with <protocols:DPoP> or an equivalent supported mechanism;
+- use of **<components:Wallet Instance Attestation (WIA)>** as client attestation material at the PAR and Token endpoints where Authorisation Code Flow is used;
+- support for **<protocols:Proof-of-possession|proof-of-possession> / <protocols:Key binding|key binding>** during credential issuance;
+- support for **<components:Wallet Unit Attestation (WUA)>** and `proofs` structures at the Credential Endpoint for device-bound issuance;
+- support for **deferred issuance** where immediate issuance is not possible;
+- support for issuance-side metadata needed to communicate issuer-defined reuse and disclosure constraints to the Wallet.
+
+Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, Wallets and Issuers SHALL additionally support the `A128GCM` and `A256GCM` algorithms, in addition to the cryptographic suites required by OpenID4VC-HAIP.
+
+Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, the following additional issuance requirements also apply:
+
+- same-device Wallet invocation SHALL support the custom URL scheme `eu-eaa-offer://`;
+- Issuer Metadata SHALL be signed metadata as defined by OpenID4VCI, and the JWS protected header SHALL carry the Issuer access certificate in `x5c` as profiled by ETSI;
+- Issuer Metadata SHALL support the `issuer_info` metadata parameter to transport issuer registration material, including the registration certificate and registrar-provided registration information, as profiled by ETSI.
+
+Under ETSI TS 119 472-3, providers shall support at least one of **`authorization_code`** or **`urn:ietf:params:oauth:grant-type:pre-authorized_code`** in the <protocols:Credential Offer>. This RFC profiles both, and treats them as first-class issuance paths. PAR requirements apply only to the Authorisation Code Flow path.
+
+For Authorisation Code Flow, this profile assumes the Wallet interacts with the <roles:Authorisation Server> using PAR, receives an authorisation code, exchanges it at the Token Endpoint, and then calls the Credential Endpoint. Under ETSI, <components:Wallet Instance Attestation (WIA)|WIA> is carried at both the PAR and Token endpoints, together with <protocols:Proof-of-possession|proof-of-possession> of the key referenced in the <components:Wallet Instance Attestation (WIA)|WIA> `cnf` claim.
+
+For device-bound issuance, ETSI requires the Credential Request to carry a `proofs` parameter containing either `jwt` or `attestation`. In the `jwt` mechanism, the Wallet proves possession of a key to be bound to the credential and carries the <components:Wallet Unit Attestation (WUA)|WUA> in the `key_attestation` protected header parameter. In the `attestation` mechanism, the Wallet carries the <components:Wallet Unit Attestation (WUA)|WUA> directly without separate <protocols:Proof-of-possession|proof-of-possession> of each attested key. The issuer's processing rules differ accordingly and will be profiled in the normative sections below.
+
+### **5.1 Credential Format Baseline**
+
+This RFC defines the interoperability baseline at protocol level and is format-aware but not format-exclusive.
+
+For APTITUDE pilots, credential formats MAY include:
+
+- **SD-JWT VC**;  
+- **ISO mdoc**, where adopted by a pilot-specific profile.
+
+Where an implementation or pilot-specific profile supports ETSI-defined credential formats with additional Issuer Metadata requirements, those additional metadata rules SHALL also apply. In particular:
+
+- support for **X509-AC EAA** issuance SHALL be reflected using the `x509_attr` format identifier;
+- support for **JSON-LD W3C VC EAA secured with JOSE** SHALL be reflected using the `vc+jwt` format identifier;
+- support for **JSON-LD W3C VC EAA secured with SD-JWT** SHALL be reflected using the `vc+sd-jwt` format identifier.
+
+To preserve a stable horizontal baseline, pilot-specific RFCs SHALL specify any additional constraints for a concrete credential format and SHALL NOT relax the mandatory requirements in this document.
+
+### **5.2 Pilot-specific extensions**
+
+Pilot-specific issuance RFCs MAY extend this profile with:
+
+- concrete credential configuration identifiers;  
+- claim set and schema rules;  
+- assurance-level requirements;  
+- format-specific proof rules;  
+- issuance policy constraints.
+
+Such extensions SHALL remain compatible with this baseline.
+
+---
+
+## **6 High-level Flows**
+
+This section describes the high-level issuance interactions supported by this RFC.
+
+This profile supports:
+
+- **wallet-initiated issuance**;
+- **issuer-initiated issuance via <protocols:Credential Offer>**;
+- **Authorisation Code Flow**;
+- **Pre-Authorised Code Flow**;
+- **immediate issuance** and **deferred issuance**.
+
+For issuance interactions using the **Authorisation Code Flow**, the Wallet uses **PAR** before user authorisation. For this path, ETSI TS 119 472-3 requires the Wallet to send **<components:Wallet Instance Attestation (WIA)>** to the **PAR Endpoint** and again to the **Token Endpoint**, together with <protocols:Proof-of-possession|proof-of-possession> of the key referenced by the <components:Wallet Instance Attestation (WIA)|WIA> `cnf` claim.
+
+For issuance interactions using the **Pre-Authorised Code Flow**, no PAR or authorisation redirect is required. The Wallet processes the <protocols:Credential Offer>, redeems the pre-authorised grant at the Token Endpoint, and proceeds to the Credential Endpoint.
+
+For **device-bound issuance**, the Wallet sends a Credential Request containing a `proofs` structure as profiled by this RFC. ETSI TS 119 472-3 requires use of **<components:Wallet Unit Attestation (WUA)>** at the Credential Endpoint, either carried in the protected header of `proofs.jwt[*]` or directly in `proofs.attestation[*]`, depending on the mechanism used.
+
+Because this RFC is issuance-only, presentation and verifier behavior are not described here except where issuer-provided issuance metadata is needed by the Wallet for later use.
+
+### **6.1 Wallet-initiated Issuance Flow**
+
+**Actors**: <roles:Holder>, Wallet, Issuer (AS and <roles:Credential Issuer>).
+
+#### **6.1.1 Configuration and discovery**
+
+1. The Wallet retrieves Issuer metadata, including at minimum:
+    - OAuth / OpenID configuration;
+    - <roles:Credential Issuer> metadata;
+    - supported credential configurations;
+    - the mapping between offered credential configurations and the request parameters needed to initiate issuance;
+    - supported grant types;
+    - supported proof methods and related <protocols:Nonce|nonce> requirements;
+    - issuance-side policy metadata required by the applicable profile.
+2. Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, the Wallet additionally retrieves and processes signed Issuer Metadata carrying:
+   - the Issuer access certificate in the JWS `x5c` protected header; and
+   - the `issuer_info` metadata parameter for issuer registration material.
+3. The Wallet determines whether the selected issuance interaction is supported through:
+    - **Authorisation Code Flow**;
+    - **Pre-Authorised Code Flow**; or
+    - both.
+
+#### **6.1.2 User selects credential**
+
+1. The <roles:Holder> chooses a credential type or credential configuration.
+2. The Wallet identifies the corresponding credential configuration and the applicable issuance path.
+3. Where the selected issuance path is wallet-initiated **Authorisation Code Flow**, the Wallet prepares an authorisation request as defined below.
+
+#### **6.1.3 Pushed Authorisation Request (PAR)**
+
+1. For wallet-initiated **Authorisation Code Flow**, the Wallet constructs an authorisation request containing at minimum:
+   - `client_id`;
+   - the relevant `scope`, `authorization_details`, or other profiled authorisation parameters;
+   - `code_challenge` using <protocols:PKCE> `S256`;
+   - `redirect_uri`;
+   - `response_type=code`;
+   - `state`;  
+   - `nonce`, where required.
+2. The Wallet sends the request to the Issuer's **PAR Endpoint**.
+3. Where this profile requires **<components:Wallet Instance Attestation (WIA)>** for the Authorisation Code Flow path, the Wallet includes:
+   - the <components:Wallet Instance Attestation (WIA)|WIA> at the PAR request; and
+   - <protocols:Proof-of-possession|proof-of-possession> of the key referenced in the <components:Wallet Instance Attestation (WIA)|WIA> `cnf` claim, according to the profiled mechanism.
+4. The PAR Endpoint validates the request and returns a `request_uri` and validity information.
+
+#### **6.1.4 User authorisation**
+
+1. The Wallet directs the <roles:Holder> to the Authorisation Endpoint using the `request_uri` obtained from PAR.
+2. The <roles:Holder> authenticates according to the Issuer's policy.
+3. The <roles:Holder> authorises the issuance transaction.
+4. The <roles:Authorisation Server> redirects back to the Wallet with an authorisation `code` and `state`.
+
+#### **6.1.5 Token request**
+
+1. The Wallet sends a token request to the Token Endpoint, including:
+   - `grant_type=authorization_code`;
+   - `code`;
+   - `redirect_uri`;
+   - `code_verifier`;
+   - client authentication using wallet attestation or the profiled mechanism.
+2. Where this profile requires **<components:Wallet Instance Attestation (WIA)>** for the Authorisation Code Flow path, the Wallet includes:
+   - the <components:Wallet Instance Attestation (WIA)|WIA> at the Token Endpoint; and
+   - <protocols:Proof-of-possession|proof-of-possession> of the key referenced in the <components:Wallet Instance Attestation (WIA)|WIA> `cnf` claim.
+3. The Token Endpoint validates the request and returns:
+   - a sender-constrained `access_token`;
+   - optional additional values such as `c_nonce`, `refresh_token`, or related token metadata, according to the applicable profile.
+
+#### **6.1.6 Credential request**
+
+1. Before calling the Credential Endpoint, the Wallet obtains a fresh <protocols:Nonce|nonce> from the Issuer's **<protocols:Nonce> Endpoint** where required by the selected proof method or issuance profile.
+2. The Wallet sends a request to the Credential Endpoint containing:
+   - `Authorization: Bearer {access_token}`;
+   - the requested credential configuration or other format-specific request parameters;
+   - a `proofs` structure or equivalent proof material, according to the selected proof mechanism.
+3. For **device-bound issuance**, the request SHALL include issuance proof material that binds the issued credential to Wallet-controlled key material.
+4. Where the selected proof method is based on `proofs.jwt`:
+   - the Wallet proves possession of the private key to be bound to the credential; and
+   - the Wallet carries the **<components:Wallet Unit Attestation (WUA)>** in the protected header parameter profiled for key attestation.
+5. Where the selected proof method is based on `proofs.attestation`:
+   - the Wallet carries the **<components:Wallet Unit Attestation (WUA)>** directly in the attestation structure; and
+   - the Issuer processes the request according to the rules applicable to attested keys under the selected profile.
+6. The <roles:Credential Issuer> validates:
+   - the access token and its sender-constraining mechanism;
+   - the credential request syntax;
+   - the <protocols:Nonce|nonce> and proof material;
+   - the applicable wallet attestation material;
+   - issuance policy;
+   - any credential-specific prerequisites.
+7. The Issuer returns the credential immediately, or signals deferred issuance.
+
+#### **6.1.7 Storage**
+
+1. The Wallet validates the returned credential and associated metadata.
+2. The Wallet stores the credential under <roles:Holder> control.
+3. The Wallet stores any issuer-provided metadata or policy information that is required for later lifecycle or disclosure handling.
+
+### **6.2 Issuer-initiated Issuance via Credential Offer**
+
+In the issuer-initiated flow, the Issuer first decides to issue and then provides a **<protocols:Credential Offer>** that the Wallet uses to continue the issuance process.
+
+**Actors**: <roles:Holder>, Wallet, Issuer, optionally <roles:Authorisation Server>.
+
+#### **6.2.1 Issuance decision**
+
+1. The <roles:Holder> interacts with the Issuer in a business process such as onboarding, enrolment, registration, or completion of an eligibility step.
+2. Following successful checks, the Issuer decides to issue one or more credentials.
+
+#### **6.2.2 Credential Offer creation**
+
+1. The Issuer constructs a <protocols:Credential Offer> that includes at minimum:
+   - the `credential_issuer` identifier;
+   - one or more offered credential identifiers or credential configurations;
+   - grant information for one or more supported issuance paths;
+   - the authorisation parameters or pre-authorised grant information needed by the Wallet to continue the flow.
+2. The <protocols:Credential Offer> MAY support either:
+   - **Authorisation Code Flow**;
+   - **Pre-Authorised Code Flow**; or
+   - both.
+
+#### **6.2.3 Credential Offer delivery and Wallet invocation**
+
+1. The Issuer delivers the offer to the <roles:Holder> by one of:
+   - displaying a QR code;  
+   - providing a link;  
+   - invoking a same-device Wallet using a supported Wallet invocation mechanism.
+1. Issuers and Wallets **SHALL** support both **same-device** and **cross-device** delivery of <protocols:Credential Offer|Credential Offers>.
+1. For **same-device**, implementations **SHALL** support at least the custom URL scheme `openid-credential-offer://`.
+1. Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, implementations **SHALL** additionally support the custom URL scheme `eu-eaa-offer://`.
+1. For **cross-device**, implementations **SHALL** support delivery through a QR code carrying a valid <protocols:Credential Offer> URI
+1. Additional wallet invocation mechanisms remain optional.
+
+#### **6.2.4 Wallet processes the offer**
+
+1. The Wallet receives the <protocols:Credential Offer>.
+1. The Wallet parses the offer and determines:
+   - the Issuer base URL;  
+   - offered credential configurations;  
+   - applicable grant information;  
+   - required authorisation parameters.
+1. The Wallet displays the offer to the <roles:Holder> and asks for confirmation to proceed.
+
+#### **6.2.5 Authorisation Code Flow variant**
+
+1. Where the <protocols:Credential Offer> uses **Authorisation Code Flow**, the Wallet initiates the authorisation process using **PAR**.
+2. The Wallet follows the same Authorisation Code Flow defined in Section 6.1 for:
+   - PAR;
+   - user authorisation;
+   - token acquisition;
+   - credential request;
+   - storage.
+3. Where this profile requires **<components:Wallet Instance Attestation (WIA)|WIA>** for this path, the Wallet sends <components:Wallet Instance Attestation (WIA)|WIA> at the PAR and Token endpoints as described in Section 6.1.
+
+#### **6.2.6 Pre-Authorised Code Flow variant**
+
+1. Where the <protocols:Credential Offer> uses **Pre-Authorised Code Flow**, the Wallet does not perform a PAR request or browser-based authorisation redirect.
+2. The Wallet sends a token request to the Token Endpoint including:
+   - `grant_type=urn:ietf:params:oauth:grant-type:pre-authorized_code`;
+   - the `pre-authorized_code`;
+   - a transaction code or user code where required by the offer or by the applicable profile;
+   - client authentication and sender-constraining material where required by the profiled mechanism.
+3. The Token Endpoint validates the pre-authorised grant and returns:
+   - a sender-constrained `access_token`;
+   - optional additional values such as `c_nonce`, `refresh_token`, or related token metadata, according to the applicable profile.
+4. The Wallet then proceeds to the Credential Endpoint as defined in Section 6.1.6.
+
+#### **6.2.7 Credential request**
+
+1. The Wallet sends a Credential Request or Batch Credential Request to the Credential Endpoint.
+2. The request includes:
+   - the access token;
+   - the requested credential configuration information;
+   - the applicable proof material;
+   - <components:Wallet Unit Attestation (WUA)|Wallet Unit Attestation> where required by the selected proof method or profile.
+3. The Issuer validates the request and either returns the credential or initiates deferred issuance.
+
+#### **6.2.8 Deferred issuance continuation**
+
+1. If issuance cannot be completed immediately, the Issuer returns the information required for deferred retrieval.
+2. The Wallet stores the transaction state and continues as defined in Section 6.3.
+
+### **6.3 Deferred Credential Request**
+
+Deferred issuance allows the Issuer to complete credential production asynchronously while preserving the issuance transaction state.
+
+1. Where the Credential Endpoint cannot immediately return the credential, the Issuer returns the information needed for later retrieval, such as a transaction identifier and any endpoint or polling details required by the profile.
+2. The Wallet stores the deferred issuance state.
+3. The Wallet later calls the **Deferred Credential Endpoint** using the required access token and deferred issuance reference.
+4. The Issuer either:
+   - returns the issued credential;
+   - indicates that issuance is still pending; or
+   - returns an error if the deferred issuance transaction cannot be completed.
+5. The Wallet repeats the retrieval only in accordance with the Issuer's indicated retry or polling guidance.
+6. Once the credential is returned, the Wallet validates and stores it as in Section 6.1.7.
+
+---
+
+## **7 Normative Requirements**
+
+This section defines the baseline normative requirements for APTITUDE implementations of the issuance profile.
+
+Unless otherwise stated, the requirements in this section apply to issuance interactions only.
+
+### **7.1 Common requirements (Wallet and Issuer)**
+
+Both Wallet and Issuer **SHALL**:
+
+1. Support OpenID4VCI 1.0 for credential issuance.
+2. Support metadata-based discovery.
+3. Support wallet-initiated issuance.
+4. Support issuer-initiated issuance via <protocols:Credential Offer>.
+5. Support at least one of the following issuance grant types:
+   - **Authorisation Code Flow**;
+   - **Pre-Authorised Code Flow**.
+6. Support **Authorisation Code Flow** where the deployment requires <roles:Holder> authentication and interactive authorisation.
+7. Support **Pre-Authorised Code Flow** where the deployment profile or issuance scenario permits issuer-initiated issuance without an interactive authorisation redirect.
+8. Support sender-constrained access tokens.
+9. Support <protocols:Proof-of-possession|proof-of-possession> / holder-binding during issuance, as required by the selected credential format and binding model.
+10. Support issuance-time metadata required to construct and process issuance requests.
+11. Support deferred issuance where the selected deployment profile or issuance process cannot always return the credential synchronously.
+12. Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, support the `A128GCM` and `A256GCM` algorithms in addition to the cryptographic suites required by OpenID4VC-HAIP.
+13. Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, support same-device Wallet invocation using the `eu-eaa-offer://` custom URL scheme.
+
+Both Wallet and Issuer **SHOULD**:
+
+1. Support both immediate and deferred issuance responses.
+2. Support Batch Credential Requests where required by a more specific pilot or credential profile.
+3. If the Wallet supports issuance notifications and receives a `notification_id` from the Issuer, support one or more Notification Requests for that `notification_id` in accordance with the applicable notification mechanism.
+
+For issuance interactions using **Authorisation Code Flow**, both Wallet and Issuer **SHALL** additionally:
+
+1. Support **Pushed Authorisation Requests (PAR)**.
+2. Support <protocols:PKCE> with the `S256` code challenge method.
+3. Support <components:Wallet Instance Attestation (WIA)|Wallet Instance Attestation> handling at the PAR and Token endpoints where required by this profile.
+
+### **7.2 Credential Offer**
+
+Issuers **SHALL**:
+
+1. Support <protocols:Credential Offer|Credential Offers> for issuer-initiated issuance.
+2. Include the `credential_issuer` identifier in the <protocols:Credential Offer>.
+3. Include one or more offered credential identifiers or credential configuration identifiers sufficient for the Wallet to determine what is being offered.
+4. Include the grant information required by the Wallet to continue issuance.
+5. Support at least one of the following grant types in <protocols:Credential Offer|Credential Offers>:
+   - `authorization_code`;
+   - `urn:ietf:params:oauth:grant-type:pre-authorized_code`.
+6. Include all grant-specific parameters needed by the Wallet to continue the flow.
+7. Ensure that the <protocols:Credential Offer> can be resolved consistently against Issuer metadata.
+8. Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile and the offer is used for same-device invocation, support delivery using the `eu-eaa-offer://` custom URL scheme.
+
+Issuers **SHOULD**:
+
+1. Support both same-device and cross-device offer delivery.
+2. Support QR-code-based delivery and URI-based invocation.
+3. Support <protocols:Credential Offer|Credential Offers> containing multiple offered credential configurations where the issuance scenario requires this.
+
+Wallets **SHALL**:
+
+1. Be able to parse <protocols:Credential Offer|Credential Offers> compliant with the applicable OpenID4VCI profile.
+2. Extract the Issuer identifier, offered credential configurations, and grant information.
+3. Determine from the offer whether the issuance path uses:
+   - Authorisation Code Flow;
+   - Pre-Authorised Code Flow; or
+   - both.
+4. Use the <protocols:Credential Offer> information consistently in later token and credential requests.
+5. Support same-device receipt via a supported Wallet invocation method.
+6. Support cross-device receipt via a QR code carrying a valid <protocols:Credential Offer> URI.
+7. Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, support same-device receipt via the `eu-eaa-offer://` custom URL scheme.
+
+Wallets **SHOULD**:
+
+1. Validate that the offered credential identifiers or configurations are supported by the Issuer metadata before proceeding.
+2. Present the <protocols:Credential Offer> to the <roles:Holder> in a way that makes the offered credentials and issuing party clear.
+
+### **7.3 Authorisation Endpoint and PAR**
+
+This section applies only to issuance transactions using **Authorisation Code Flow**.
+
+Issuers **SHALL**:
+
+1. Expose a PAR endpoint for issuance transactions using Authorisation Code Flow.
+2. Require PAR for all authorisation requests under this profile.
+3. Reject direct front-channel authorisation requests not preceded by PAR where this profile requires PAR.
+4. Require the Wallet to include the credential-related authorisation parameters needed for the selected credential configuration and issuance path.
+5. Require <protocols:PKCE> with `S256`.
+6. Require consistent use of `client_id` across PAR and Token requests.
+7. Require <components:Wallet Instance Attestation (WIA)> at the PAR endpoint where this profile applies ETSI-aligned wallet attestation.
+8. Require <protocols:Proof-of-possession|proof-of-possession> of the public key referenced in the <components:Wallet Instance Attestation (WIA)|WIA> `cnf` claim.
+9. Verify that the <components:Wallet Instance Attestation (WIA)|WIA> signature validates under the <roles:Wallet Provider> public key from the applicable trusted list.
+10. Verify that the <components:Wallet Instance Attestation (WIA)|WIA> is not expired.
+11. Verify that the <protocols:Proof-of-possession|proof-of-possession> validates under the public key referenced in the <components:Wallet Instance Attestation (WIA)|WIA> `cnf` claim.
+
+Wallets **SHALL**:
+
+1. Use PAR for all Authorisation Code Flow requests under this profile.
+2. Include the required credential-related authorisation parameters.
+3. Include `client_id`, `response_type=code`, `redirect_uri`, `state`, and <protocols:PKCE> parameters.
+4. Include `nonce` where required by the selected profile or issuer policy.
+5. Include <components:Wallet Instance Attestation (WIA)|WIA> at the PAR endpoint where this profile requires it.
+6. Include <protocols:Proof-of-possession|proof-of-possession> of the public key referenced in the <components:Wallet Instance Attestation (WIA)|WIA> `cnf` claim.
+7. Ensure that `client_id` is used consistently across PAR and Token requests.
+
+Wallets **SHOULD**:
+
+1. Check metadata in advance to determine whether additional authorisation parameters or `authorization_details` are required.
+2. Treat expired or rejected <components:Wallet Instance Attestation (WIA)|WIA> material as a recoverable client-authentication failure and obtain fresh attestation material before retrying.
+
+### **7.4 Token Endpoint and Wallet Attestation**
+
+This section applies to:
+
+- **Authorisation Code Flow**, and
+- **Pre-Authorised Code Flow** where the selected deployment requires wallet client authentication or equivalent sender-constraining material at the Token Endpoint.
+
+For **Authorisation Code Flow**, Wallets **SHALL**:
+
+1. Send a Token Request containing:
+   - `grant_type=authorization_code`;
+   - `code`;
+   - `redirect_uri`;
+   - `code_verifier`.
+2. Include <components:Wallet Instance Attestation (WIA)|WIA> at the Token Endpoint where this profile applies ETSI-aligned wallet attestation.
+3. Include <protocols:Proof-of-possession|proof-of-possession> of the public key referenced in the <components:Wallet Instance Attestation (WIA)|WIA> `cnf` claim.
+4. Ensure consistency between the authenticated Wallet identity and the `client_id` used earlier in the transaction.
+
+For **Pre-Authorised Code Flow**, Wallets **SHALL**:
+
+1. Send a Token Request containing:
+   - `grant_type=urn:ietf:params:oauth:grant-type:pre-authorized_code`;
+   - the `pre-authorized_code`;
+   - any transaction code or user code required by the offer or deployment profile.
+2. Include any client-authentication or sender-constraining material required by the selected deployment profile.
+3. Use the returned access token consistently in subsequent credential requests.
+
+Issuers **SHALL**:
+
+1. Expose a Token Endpoint.
+2. Validate the Token Request according to the applicable grant type.
+3. For Authorisation Code Flow, validate <protocols:PKCE> inputs and authorisation-code state as required by OAuth/OpenID4VCI.
+4. Where <components:Wallet Instance Attestation (WIA)|WIA> is required, validate:
+   - the <components:Wallet Instance Attestation (WIA)|WIA> signature under the <roles:Wallet Provider> public key from the applicable trusted list;
+   - the <components:Wallet Instance Attestation (WIA)|WIA> expiry;
+   - the <protocols:Proof-of-possession|proof-of-possession> under the public key referenced in the <components:Wallet Instance Attestation (WIA)|WIA> `cnf` claim.
+5. Issue sender-constrained access tokens.
+6. Bind token usage to the Wallet according to the selected sender-constraining mechanism.
+7. Return any `c_nonce` or related token metadata needed by the selected proof mechanism.
+
+Issuers **SHOULD**:
+
+1. Support refresh tokens where long-lived issuance processes, renewal, or deferred issuance need them.
+2. Consider the sensitivity of the credential type before issuing long-lived refresh tokens.
+
+Wallets **SHALL**:
+
+1. Support sender-constrained token usage in subsequent calls to the Credential Endpoint.
+2. Process returned `c_nonce` or equivalent issuance-related token metadata where needed by the selected proof mechanism.
+
+### **7.5 Credential Endpoint**
+
+Issuers **SHALL**:
+
+1. Expose a Credential Endpoint.
+2. Support issuance requests for the credential configurations published in Issuer metadata.
+3. Validate the access token and sender constraint.
+4. Validate the credential request syntax and requested credential configuration.
+5. For device-bound issuance, require the `proofs` parameter.
+6. Require that `proofs` contain either:
+   - the `jwt` child member; or
+   - the `attestation` child member.
+7. Validate the <protocols:Nonce|nonce> and proof material according to the selected proof method.
+8. Validate <components:Wallet Unit Attestation (WUA)> according to the selected proof method.
+9. Return either:
+   - the issued credential; or
+   - a deferred issuance response.
+
+Wallets **SHALL**:
+
+1. Send a Credential Request containing the requested credential configuration or other format-specific request parameters.
+2. For device-bound issuance, include the `proofs` parameter.
+3. Populate `proofs` using either:
+   - `proofs.jwt`; or
+   - `proofs.attestation`;
+  according to the selected binding model and issuer requirements.
+4. Obtain and use a fresh <protocols:Nonce|nonce> from the Issuer's <protocols:Nonce> Endpoint where required by the selected proof method.
+5. Validate the returned credential, including issuer binding and format-specific integrity checks.
+6. Store only credentials that have successfully passed Wallet validation.
+
+### **7.5.1 Credential Request using `proofs.jwt`**
+
+Wallets **SHALL**:
+
+1. Include exactly one element in the `jwt` array.
+2. Include a valid <protocols:Nonce|nonce> claim in the JWT body, obtained from the Issuer's <protocols:Nonce> Endpoint.
+3. Include the `key_attestation` protected header parameter.
+4. Carry the <components:Wallet Unit Attestation (WUA)> in that `key_attestation` parameter.
+5. Ensure that the <components:Wallet Unit Attestation (WUA)|WUA> contains one or more attested public keys owned by the <components:Wallet Unit>.
+6. Sign the JWT using the private key corresponding to the first public key in the `attested_keys` claim of the <components:Wallet Unit Attestation (WUA)|WUA>.
+
+Issuers **SHALL**:
+
+1. Verify that the <components:Wallet Unit Attestation (WUA)|WUA> signature in `key_attestation` validates under the <roles:Wallet Provider> public key from the applicable trusted list.
+2. Verify that the JWT signature validates under the first public key in the `attested_keys` array of the <components:Wallet Unit Attestation (WUA)|WUA>.
+3. Verify that the JWT contains a valid <protocols:Nonce|nonce> from the Issuer's <protocols:Nonce> Endpoint.
+4. Generate as many credentials as there are attested public keys in the <components:Wallet Unit Attestation (WUA)|WUA>, where the applicable profile requires multi-key issuance.
+5. Bind each issued credential to one of the attested public keys.
+6. Ensure that no two issued credentials in the transaction are bound to the same public key.
+
+### **7.5.2 Credential Request using `proofs.attestation`**
+
+Wallets **SHALL**:
+
+1. Include exactly one element in the `attestation` array.
+2. Include a valid <protocols:Nonce|nonce> claim in the JWT body, obtained from the Issuer's <protocols:Nonce> Endpoint.
+3. Carry the <components:Wallet Unit Attestation (WUA)> directly as the single attestation element.
+
+Issuers **SHALL**:
+
+1. Verify that the <components:Wallet Unit Attestation (WUA)|WUA> signature validates under the <roles:Wallet Provider> public key from the applicable trusted list.
+2. Generate as many credentials as there are attested public keys in the <components:Wallet Unit Attestation (WUA)|WUA>, where the applicable profile requires multi-key issuance.
+3. Bind each issued credential to one of the attested public keys.
+4. Ensure that no two issued credentials in the transaction are bound to the same public key.
+
+Issuers **SHOULD**:
+
+1. Reject malformed or semantically inconsistent `proofs` structures with explicit error information where possible.
+2. Distinguish clearly between <protocols:Nonce|nonce> failure, attestation failure, proof failure, and policy failure.
+
+### **7.6 Deferred Credential Endpoint**
+
+Issuers **SHALL**:
+
+1. Expose a Deferred Credential Endpoint where the deployment supports deferred issuance.
+2. Return the information needed by the Wallet to retrieve deferred credentials.
+3. Validate deferred retrieval tokens, references, or transaction identifiers.
+4. Publish the Deferred Credential Endpoint in metadata where supported.
+5. Return explicit terminal errors for expired, denied, or otherwise failed deferred issuance transactions.
+
+Issuers **SHOULD**:
+
+1. Provide retry guidance or polling hints.
+2. Preserve transaction state for a duration appropriate to the issuance process.
+
+Wallets **SHALL**:
+
+1. Recognise deferred issuance responses.
+2. Persist the transaction state needed to continue deferred retrieval.
+3. Poll or retry according to the Issuer's guidance until completion or terminal failure.
+4. Distinguish pending and failed issuance states in Wallet behaviour.
+
+Wallets **SHOULD**:
+
+1. Apply retry intervals and back-off.
+2. Allow the <roles:Holder> to stop retrying or resume later.
+
+### **7.7 Server Metadata**
+
+Issuers **SHALL** publish metadata that includes:
+
+1. OAuth 2.0 / OpenID configuration, including Authorisation, Token, and PAR endpoints.
+2. <roles:Credential Issuer> metadata describing supported credential configurations.
+3. The Credential Endpoint location.
+4. The Deferred Credential Endpoint location, where supported.
+5. Any relevant proof types, credential format support, and associated configuration data required by Wallets.
+6. The format identifiers `x509_attr`, `vc+jwt`, and/or `vc+sd-jwt`, where the Issuer supports the corresponding ETSI-defined credential formats.
+7. Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, signed Issuer Metadata whose JWS protected header carries the Issuer access certificate in `x5c`.
+8. Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, the `issuer_info` metadata parameter carrying issuer registration material, including the registration certificate and registrar dataset, as profiled by ETSI.
+
+Wallets **SHALL**:
+
+1. Retrieve and process Issuer metadata.
+2. Use metadata to construct authorisation and credential requests.
+3. Use metadata to interpret <protocols:Credential Offer|Credential Offers> and supported credential configurations.
+4. Where notification support is implemented and the Issuer provides a `notification_id`, use Issuer metadata or the applicable profile to determine how Notification Requests are sent.
+5. Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, process signed Issuer Metadata `x5c` and `issuer_info` content as part of issuer validation and registration-material handling.
+
+---
+
+## **8 Interface Definitions**
+
+This section defines the logical interfaces for conformance testing. Exact URL paths are deployment-specific and discovered through metadata.
+
+### **8.1 Wallet Invocation Interface**
+
+- **Direction**: Issuer to Wallet  
+- **Transport**: custom URI, QR code, or equivalent Wallet invocation mechanism
+
+Wallets and Issuers **SHOULD** support at least one interoperable Wallet invocation method suitable for both same-device and cross-device use.
+
+Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, the same-device invocation method **SHALL** include the `eu-eaa-offer://` custom URL scheme.
+
+### **8.2 Credential Offer Interface**
+
+- **Direction**: Issuer to Wallet
+
+The <protocols:Credential Offer> **SHALL** contain at least:
+
+- `credential_issuer`;  
+- grant information;  
+- credential identifiers or credential configuration identifiers;  
+- the information the Wallet needs to continue the issuance flow.
+
+The exact JSON structure SHALL comply with OpenID4VCI.
+
+### **8.3 PAR Endpoint**
+
+- **Direction**: Wallet to Issuer (AS)  
+- **Method**: `POST`
+
+#### **Request (logical fields)**
+
+- `client_id`  
+- credential-related authorisation parameters  
+- `code_challenge`  
+- `code_challenge_method=S256`  
+- `redirect_uri`  
+- `response_type=code`  
+- `state`  
+- optional `nonce`
+
+#### **Response**
+
+- `request_uri`  
+- `expires_in`
+
+### **8.4 Token Endpoint**
+
+- **Direction**: Wallet to Issuer (AS)  
+- **Method**: `POST`
+
+#### **Request (logical fields)**
+
+- `grant_type=authorization_code`  
+- `code`  
+- `redirect_uri`  
+- `code_verifier`  
+- client authentication material
+
+#### **Response**
+
+- `access_token`  
+- `token_type`  
+- `expires_in`  
+- optional `c_nonce`  
+- optional `refresh_token`
+
+### **8.5 Credential Endpoint**
+
+- **Direction**: Wallet to Issuer  
+- **Method**: `POST`
+
+#### **Request (logical fields)**
+
+- `Authorization: Bearer {access_token}`  
+- requested credential configuration or identifier  
+- format-specific request information  
+- proof material
+
+#### **Response**
+
+- issued credential(s), or  
+- deferred issuance response
+
+### **8.6 Nonce Endpoint**
+
+- **Direction**: Wallet to Issuer  
+- **Method**: `POST` or as defined by metadata/profile
+
+If the Issuer requires a fresh <protocols:Nonce|nonce> for proof generation, the Issuer **SHALL** expose and document the relevant mechanism in metadata.
+
+### **8.7 Notification Interface**
+
+- **Direction**: Wallet to Issuer  
+- **Method**: `POST` or as defined by metadata/profile
+
+If the deployment supports issuance notifications and the Issuer provides a `notification_id`, the Wallet **SHOULD** send one or more Notification Requests for that `notification_id` using the mechanism defined by the applicable profile or Issuer metadata.
+
+### **8.8 Deferred Credential Endpoint**
+
+- **Direction**: Wallet to Issuer  
+- **Method**: `POST`
+
+#### **Request (logical fields)**
+
+- authorisation information or deferred token  
+- transaction identifier, where applicable
+
+#### **Response**
+
+- issued credential(s), or  
+- pending status with retry guidance, or  
+- terminal failure
+
+### **8.9 Metadata Endpoints**
+
+Issuers **SHALL** publish:
+
+- OAuth / OpenID discovery metadata;  
+- <roles:Credential Issuer> metadata.
+
+Metadata SHALL provide enough information for a conforming Wallet to discover and use:
+
+- authorisation endpoint;  
+- token endpoint;  
+- PAR endpoint;  
+- credential endpoint;  
+- deferred credential endpoint, where applicable;  
+- supported credential configurations;  
+- supported proof types and formats.
+
+Where this RFC is used as an ETSI TS 119 472-3 aligned issuance profile, the metadata set **SHALL** additionally provide:
+
+- signed Issuer Metadata with the Issuer access certificate transported in the JWS protected header `x5c`; and
+- the `issuer_info` metadata parameter carrying issuer registration material, including the registration certificate and registrar dataset, as profiled by ETSI.
+
+---
+
+## **9 Conformance**
+
+An implementation **conforms to this specification as a Wallet** if it:
+
+1. Implements the Wallet requirements in Sections 6 and 7
+2. Supports the Wallet-side interfaces and behaviours defined in Section 8
+3. Uses OpenID4VCI 1.0 and the APTITUDE issuance profile constraints defined in this RFC.
+
+An implementation **conforms to this specification as an Issuer** if it:
+
+1. Implements the Issuer requirements in Sections 6 and 7
+2. Publishes the required metadata.
+3. Provides the issuance interfaces defined in Section 8
+4. Applies the APTITUDE issuance baseline consistently across supported credential configurations.
+
+Pilot-specific profiles MAY define additional constraints for specific credential types or domains. Such profiles SHALL NOT relax the mandatory requirements in this document.
+
+9.1 Scope of the Conformance Matrix
+
+This conformance matrix verifies baseline protocol interoperability between an Issuer or <components:Wallet Unit> under test and the reference issuance endpoints defined by this APTITUDE Issuance Profile. It is intended to confirm correct support for representative OpenID4VCI v1.0 issuance flows covered by this RFC, including wallet-initiated and issuer-initiated issuance.
+
+The matrix is a protocol interoperability matrix, not a complete ARF/CIR compliance assessment. It focuses on issuance flow processing, <protocols:Credential Offer> handling, PAR-based authorisation, token acquisition, proof-bound credential requests, deferred issuance handling, and metadata-driven endpoint use within the scope of this profile.
+
+It does not exhaustively test broader trust, governance, semantic, privacy, supervisory, or deployment-specific obligations. Where ARF or CIR references are included, they provide traceability and alignment for the issuance interoperability capability being exercised, rather than full normative coverage of the broader requirement domain. This is consistent with the RFC’s explicitly horizontal, cross-pilot scope and its stated out-of-scope exclusions.
+
+---
+
+## **10 Conformance Check Catalogue and Deployed Test Matrix**
+
+### 10.1 Conformance Check Catalogue
+
+| Check ID | Conformance Check | What Is Verified At Runtime | ARF / CIR Linkage |
+| --- | --- | --- | --- |
+| `VCI-CHECK-01` | Credential offer resolution and processing | The wallet resolves the credential offer or offer URI and processes the issuance entrypoint without transport or parsing failure. | CIR credential offer interface; ARF issuer-initiated and wallet-initiated issuance baseline |
+| `VCI-CHECK-02` | Authorization-code flow handling | The wallet completes the authorization-code flow through authorization, code reception, and token redemption. | ARF wallet-initiated issuance flow; CIR authorization-code issuance |
+| `VCI-CHECK-03` | <protocols:PKCE> enforcement | Token redemption requires the correct <protocols:PKCE> verifier for authorization-code issuance. | CIR token endpoint security; ARF authorization security baseline |
+| `VCI-CHECK-03A` | <components:Wallet Instance Attestation (WIA)\|Wallet Instance Attestation> handling | For authorization-code issuance where the profile requires wallet attestation, the wallet sends <components:Wallet Instance Attestation (WIA)\|WIA> at the PAR and Token endpoints, proves possession of the key referenced in the <components:Wallet Instance Attestation (WIA)\|WIA> `cnf` claim, and the issuer validates those inputs. | ETSI-aligned PAR and token endpoint attestation handling; ARF wallet attestation baseline |
+| `VCI-CHECK-04` | Pre-authorized code validation | Token exchange rejects unknown or expired pre-authorized codes and correctly handles pre-authorized issuance state. | CIR token endpoint behavior; ARF issuer-initiated issuance baseline |
+| `VCI-CHECK-05` | Proof container and selector validation | Credential requests use the correct selector model, reject legacy `proof`, require `proofs`, and enforce exactly one proof type. | CIR credential endpoint and proof request shape; ARF <protocols:Proof-of-possession\|proof-of-possession> baseline |
+| `VCI-CHECK-06` | <roles:Holder> proof validation | The issuer validates proof signature, proof key resolution, `aud`, freshness, `nonce`, and where applicable `iss`. | CIR proof validation requirements; ARF proof binding and replay protection |
+| `VCI-CHECK-06A` | <components:Wallet Unit Attestation (WUA)\|Wallet Unit Attestation> handling | The credential request carries <components:Wallet Unit Attestation (WUA)\|WUA> in the correct location for the selected proof method, the issuer validates the <components:Wallet Unit Attestation (WUA)\|WUA>, and the issued credential is bound according to the attested key material. | ETSI-aligned credential endpoint attestation handling; ARF key-attestation and holder-binding baseline |
+| `VCI-CHECK-07` | Signature-profile interoperability | The issuance flow interoperates with the issuer signature reference/profile variant configured for the deployed case. | ARF interoperability across supported signing models; CIR credential format and metadata support |
+| `VCI-CHECK-08` | mdoc-specific proof handling | mdoc issuance requires the mdoc-appropriate proof path and rejects JWT proof for `mso_mdoc` requests. | ARF credential-format interoperability; CIR credential format support |
+| `VCI-CHECK-09` | tx-code offer-step handling | The wallet can process issuance flows that advertise a tx-code step, even where server-side tx-code enforcement is partial. | CIR credential offer and token interaction behavior; ARF issuer-initiated issuance support |
+| `VCI-CHECK-10` | `A128GCM` algorithm support | A deployed issuance flow succeeds when the relevant encrypted object in the profiled exchange is produced and consumed using `enc=A128GCM`. | ETSI TS 119 472-3 aligned cryptographic algorithm support; HAIP-compatible encrypted exchange handling |
+| `VCI-CHECK-11` | `A256GCM` algorithm support | A deployed issuance flow succeeds when the relevant encrypted object in the profiled exchange is produced and consumed using `enc=A256GCM`. | ETSI TS 119 472-3 aligned cryptographic algorithm support; HAIP-compatible encrypted exchange handling |
+
+### 10.2 Deployed Test Case Matrix
+
+| Test Case ID | Deployed Scenario | Request Profile / Variant | Checks Covered | Expected Outcome |
+| --- | --- | --- | --- | --- |
+| `VCI-001` | Authorization-code flow, SD-JWT, JWK signature | PID SD-JWT issuance with JWK-based issuer signature selection | `VCI-CHECK-01`, `VCI-CHECK-02`, `VCI-CHECK-03`, `VCI-CHECK-03A`, `VCI-CHECK-05`, `VCI-CHECK-06`, `VCI-CHECK-06A`, `VCI-CHECK-07` | Successful end-to-end authorization-code issuance for the JWK-signature SD-JWT case |
+| `VCI-002` | Authorization-code flow, SD-JWT, KID-JWK signature | PID SD-JWT issuance with KID-JWK issuer signature selection | `VCI-CHECK-01`, `VCI-CHECK-02`, `VCI-CHECK-03`, `VCI-CHECK-03A`, `VCI-CHECK-05`, `VCI-CHECK-06`, `VCI-CHECK-06A`, `VCI-CHECK-07` | Successful end-to-end authorization-code issuance for the KID-JWK-signature SD-JWT case |
+| `VCI-004` | Authorization-code flow, SD-JWT, DID:web signature | PID SD-JWT issuance with DID:web issuer signature selection | `VCI-CHECK-01`, `VCI-CHECK-02`, `VCI-CHECK-03`, `VCI-CHECK-03A`, `VCI-CHECK-05`, `VCI-CHECK-06`, `VCI-CHECK-06A`, `VCI-CHECK-07` | Successful end-to-end authorization-code issuance for the DID:web-signature SD-JWT case |
+| `VCI-005` | Authorization-code flow, mdoc, X.509 | mdoc issuance with X.509 signature profile | `VCI-CHECK-01`, `VCI-CHECK-02`, `VCI-CHECK-03`, `VCI-CHECK-03A`, `VCI-CHECK-05`, `VCI-CHECK-06`, `VCI-CHECK-06A`, `VCI-CHECK-07`, `VCI-CHECK-08` | Successful end-to-end authorization-code issuance for the mdoc X.509 case, or explicit rejection of the wrong proof type |
+| `VCI-006` | Pre-authorized code flow, SD-JWT, X.509 | PID SD-JWT issuance with X.509 signature profile and no tx-code step | `VCI-CHECK-01`, `VCI-CHECK-04`, `VCI-CHECK-05`, `VCI-CHECK-06`, `VCI-CHECK-06A`, `VCI-CHECK-07` | Successful pre-authorized issuance for the SD-JWT X.509 case |
+| `VCI-007` | Pre-authorized code flow with tx-code metadata, SD-JWT, X.509 | PID SD-JWT issuance with X.509 signature profile and tx-code metadata | `VCI-CHECK-01`, `VCI-CHECK-04`, `VCI-CHECK-05`, `VCI-CHECK-06`, `VCI-CHECK-06A`, `VCI-CHECK-07`, `VCI-CHECK-09` | Successful pre-authorized issuance for the tx-code SD-JWT X.509 case |
+| `VCI-008` | Pre-authorized code flow, mdoc, X.509 | mdoc issuance with X.509 signature profile and no tx-code step | `VCI-CHECK-01`, `VCI-CHECK-04`, `VCI-CHECK-05`, `VCI-CHECK-06`, `VCI-CHECK-06A`, `VCI-CHECK-07`, `VCI-CHECK-08` | Successful pre-authorized issuance for the mdoc X.509 case, or explicit rejection of the wrong proof type |
+| `VCI-009` | Authorization-code flow, SD-JWT, `A128GCM` | PID SD-JWT issuance where the relevant encrypted exchange uses `enc=A128GCM` | `VCI-CHECK-01`, `VCI-CHECK-02`, `VCI-CHECK-03`, `VCI-CHECK-03A`, `VCI-CHECK-05`, `VCI-CHECK-06`, `VCI-CHECK-06A`, `VCI-CHECK-07`, `VCI-CHECK-10` | Successful end-to-end authorization-code issuance when the profiled encrypted exchange uses `A128GCM` |
+| `VCI-010` | Authorization-code flow, SD-JWT, `A256GCM` | PID SD-JWT issuance where the relevant encrypted exchange uses `enc=A256GCM` | `VCI-CHECK-01`, `VCI-CHECK-02`, `VCI-CHECK-03`, `VCI-CHECK-03A`, `VCI-CHECK-05`, `VCI-CHECK-06`, `VCI-CHECK-06A`, `VCI-CHECK-07`, `VCI-CHECK-11` | Successful end-to-end authorization-code issuance when the profiled encrypted exchange uses `A256GCM` |
+
+---
+
+## **References**
+
+1. OpenID Foundation. OpenID for Verifiable Credential Issuance 1.0.
+2. OpenID Foundation. OpenID4VC High Assurance Interoperability Profile 1.0.
+3. OpenID Foundation. OpenID for Verifiable Presentations 1.0.
+4. APTITUDE project architecture, interoperability, and ITB+ artefacts (to be referenced by the project).
+5. ETSI TS 119 472-3 V1.1.1 (2026-03), *Electronic Signatures and Trust Infrastructures (ESI); Profiles for Electronic Attestation of Attributes; Part 3: Profiles for issuance of EAA or PID*, <https://www.etsi.org/deliver/etsi_ts/119400_119499/11947203/01.01.01_60/ts_11947203v010101p.pdf>

--- a/docs/horizontal-RFCs/RFC002.md
+++ b/docs/horizontal-RFCs/RFC002.md
@@ -1,0 +1,1119 @@
+# **APTITUDE RFC-02 Presentation Profile**
+
+**Status:** Draft  
+**Type:** Cross-pilot baseline RFC  
+**Scope:** Credential Presentation / Verification  
+**Target protocols:** OpenID4VP v1.0  
+**Related profiles:** HAIP (where applicable)  
+**Companion RFC:** RFC-01 Issuance Profile
+
+## **Authors**
+
+- Nikos Triantafyllou, University of the Aegean
+
+## **Reviewers**
+
+1. Degani Giancarlo, Infocert
+2. Andreea Prian, IDAKTO
+3. Leonardo Pio Palumbo, ipzs
+4. Leone Riello, Infocert
+5. George Fourtounis, GRNET
+
+---
+
+## **1\. Introduction**
+
+This document defines the **APTITUDE Presentation Profile** for interoperable credential verification across APTITUDE pilots.
+
+It specifies a baseline, cross-pilot profile for presentation and verification of verifiable credentials, aligned with the Architecture and Reference Framework (ARF), and based on **OpenID for Verifiable Presentations (OpenID4VP) v1.0**. Where applicable, the profile incorporates relevant choices from the **OpenID4VC High Assurance Interoperability Profile (HAIP)**.
+
+The purpose of this RFC is to establish a stable starting point for interoperability across APTITUDE pilots by defining:
+
+- common presentation and verification requirements  
+- roles and interfaces between wallets and verifiers  
+- baseline security and privacy expectations  
+- support for same-device and cross-device presentation patterns  
+- a requirements baseline that can be mapped into corresponding **ITB+ conformance test cases**
+
+This RFC is intended to support interoperability first. Pilot-specific or sector-specific extensions may be added later, but they should not weaken the baseline requirements defined here.
+
+---
+
+## **2\. Scope**
+
+This RFC defines the conformance profile for **credential presentation and verification** in APTITUDE.
+
+It covers requirements for:
+
+- **<components:Wallet Unit|Wallet Units> / Wallets** acting on behalf of the <roles:Holder>  
+- **<roles:Verifier|Verifiers> / Relying Parties** initiating presentation requests and validating responses
+
+This profile defines a baseline for presentation interoperability using **OpenID4VP v1.0**.
+
+This RFC profiles presentation under two normative tracks:
+
+- **SD-JWT VC track** — profiled under the generic APTITUDE OpenID4VP presentation mode, including selective-disclosure presentation patterns supported by the selected credential profile
+- **ISO/IEC 18013-7 remote mdoc track** — profiled separately under an ISO/IEC TS 18013-7-aligned mode for remote presentation of `mso_mdoc` credentials; remote presentation of `mso_mdoc` credentials SHALL conform to ISO/IEC TS 18013-7 Annex B and the corresponding OpenID4VP mdoc processing rules used to carry the ISO `DeviceResponse`
+
+This RFC includes baseline requirements for:
+
+- construction and processing of presentation requests
+- Wallet invocation for same-device and cross-device presentation flows
+- presentation response submission and verifier-side validation
+- holder consent and release of requested data
+- baseline privacy and security requirements for request/response handling
+
+For the ETSI-aligned presentation flows in scope for this RFC, the following stricter requirements apply:
+
+- signed <protocols:Request Object|Request Objects>
+- structured <roles:Verifier> identification
+- request integrity and audience binding
+- support for ETSI-aligned authorization-endpoint invocation using the `eu-eaap://` scheme where that invocation method is applied by the deployment profile
+- encrypted presentation responses
+- profile-specific request metadata and proof-binding requirements
+
+For the ISO/IEC 18013-7 remote mdoc track, the following additional requirements apply:
+
+- format-specific wallet invocation using the `mdoc-openid4vp://` scheme
+- `mso_mdoc` request construction with document type, <credentials:Namespace|namespace>, and element identifiers
+- `vp_token` carrying the base64url-encoded ISO `DeviceResponse` CBOR structure
+- `SessionTranscript` and handover construction binding the response to the originating request
+- verifier-side validation of the returned mdoc presentation object against the reconstructed session context
+
+This RFC does **not** define:
+
+- sector-specific credential semantics  
+- trust framework governance rules or verifier registration schemes at baseline RFC level
+- mandatory verifier trust anchors or trusted-list processing rules at baseline RFC level
+- full protocol profiling of ISO/IEC 18013-5 proximity device retrieval and reader authentication requirements
+- JSON-LD W3C VC presentation requirements
+- pilot-specific UI requirements  
+- detailed test assertions; these are derived into the ITB+ test suite from the requirements matrix in this document
+
+Where this RFC defines structural elements that may also be used by a trust framework or verifier registration ecosystem, those definitions are included only to support interoperability of the protocol exchange and do not by themselves establish trust, registration, or legal reliance.
+
+---
+
+## **3\. Normative Language**
+
+The key words **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **MAY**, and **OPTIONAL** in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+---
+
+## **4\. Roles and Components**
+
+This RFC uses the following roles:
+
+### **4.1 Holder**
+
+The **<roles:Holder>**, as defined in the APTITUDE glossary and aligned with the ARF notion of (Wallet) User, is the natural person or legal representative controlling the Wallet and authorising the presentation of credentials.
+
+### **4.2 Wallet Unit / Wallet**
+
+The **Wallet Unit** is the <components:Wallet Unit> as defined in the ARF and APTITUDE glossary, including one or more <components:Wallet Instance|Wallet Instances> on the Holder’s device or environment. In this RFC, the term **Wallet** refers to the Wallet Unit (and its Wallet Instances) when the distinction is not material, acting on behalf of the <roles:Holder> to manage credentials and respond to presentation requests.
+
+### **4.3 Verifier**
+
+The **<roles:Verifier>**, as defined in the APTITUDE glossary and aligned with the ARF notion of (Wallet-) Relying Party, is the entity requesting verifiable presentations, validating the response, and making an authorisation or business decision based on the outcome.
+
+### **4.4 Verifier Backend**
+
+The **<roles:Verifier Backend>**, as defined in the APTITUDE glossary, is the server-side component that creates presentation requests, receives presentation responses, validates them, and returns the result to the relying application.
+
+### **4.5 Relying Application**
+
+The **<roles:Relying Application>**, as defined in the APTITUDE glossary, is the user-facing application, service, or workflow in which credential verification is performed.
+
+---
+
+## **5\. Protocol Overview**
+
+The APTITUDE Presentation Profile is based on **OpenID4VP v1.0** as the baseline presentation protocol for requesting and submitting credential presentations.
+
+This RFC profiles two credential presentation tracks:
+
+- **SD-JWT VC track** — presentation using the generic APTITUDE OpenID4VP mode with ETSI-aligned request and response constraints
+- **ISO/IEC 18013-7 remote mdoc track** — presentation of `mso_mdoc` credentials using an ISO/IEC TS 18013-7-aligned OpenID4VP mdoc mode with dedicated request construction, session binding, response structure, and verifier validation rules
+
+This RFC defines a **baseline APTITUDE presentation mode** for the non-API-mediated presentation flows in scope for APTITUDE and applies the relevant **ETSI TS 119 472-2 / OpenID4VC-HAIP-aligned** request and response constraints as mandatory requirements for the SD-JWT VC track. For the mdoc track, the RFC defines a separate ISO/IEC TS 18013-7-aligned presentation mode with format-specific normative requirements.
+
+### **5.1 Baseline APTITUDE presentation mode**
+
+In the baseline mode:
+
+- the <roles:Verifier> creates a <protocols:Presentation Request> using OpenID4VP-compatible request parameters
+- the Wallet is invoked using an interoperable same-device or cross-device mechanism supported by the deployment context
+- the Wallet validates the request before showing it to the <roles:Holder>
+- the <roles:Holder> reviews the request and explicitly approves release
+- the Wallet generates a presentation response using the selected credential format
+- the Wallet submits the response using the response mechanism defined by the request
+- the <roles:Verifier> validates the response and returns the outcome to the relying application
+
+The baseline mode requires interoperability at protocol level, but does **not** require a specific verifier trust framework, verifier registration system, or mandatory trusted-list processing model at RFC level. Structural request elements may still be used where supported, but their presence alone does not establish trust, legal reliance, or registration status.
+
+### **5.2 ETSI-aligned mandatory requirements**
+
+For the presentation flows in scope for this RFC, the presentation exchange SHALL apply stricter ETSI-aligned constraints for request integrity, verifier identification, response protection, and proof binding.
+
+The following ETSI-aligned constraints are mandatory:
+
+- use signed <protocols:Request Object|Request Objects>
+- use `client_id` with the Client Identifier Prefix `x509_hash`
+- include structured verifier identification
+- include `client_metadata` and related verifier key material
+- include `verifier_info` with RP-registrar/registry-related verifier information
+- apply audience restriction using `aud` and enforce <protocols:Nonce|nonce> correlation
+- use encrypted authorization or presentation responses
+- apply profile-specific proof-binding requirements for the selected credential format
+
+In this RFC, these ETSI-aligned structures are included to support interoperability of the protocol exchange. However, the RFC does **not** define the governance, issuance, validation, or legal effect of verifier registration certificates, trust anchors, or trusted status lists.
+
+### **5.3 Supported presentation patterns**
+
+This RFC supports **non-API-mediated** presentation patterns:
+
+- **same-device presentation**, where the Wallet is invoked on the same device as the relying application; and
+- **cross-device presentation**, where the request is transferred across devices, typically using QR-based or link-based handoff
+
+For the **SD-JWT VC track**, APTITUDE requires support for interoperable invocation methods suitable for same-device and cross-device non-API-mediated use.
+
+For the **ISO/IEC 18013-7 remote mdoc track**, same-device remote presentation is the ISO-aligned mode. Cross-device mdoc presentation is not defined under the ISO/IEC 18013-7-aligned profile in this RFC. If APTITUDE requires cross-device mdoc presentation in future, it SHALL be described as a separate profile claim and SHALL NOT be presented as ISO/IEC 18013-7 alignment.
+
+API-mediated presentation flows are currently out of scope for this RFC. Future revisions may include API-mediated flows (for example, DC API) where required by agreed use cases.
+
+### **5.4 High-level presentation sequence**
+
+At a high level, the presentation process is:
+
+1. The <roles:Verifier> creates a <protocols:Presentation Request>.
+2. The Wallet is invoked through a supported method.
+3. The Wallet validates the request.
+4. The <roles:Holder> reviews the request and provides consent.
+5. The Wallet generates a presentation response.
+6. The Wallet submits the presentation response to the <roles:Verifier>.
+7. The <roles:Verifier> validates the response and returns the outcome.
+
+### **5.5 Relation to ETSI-aligned presentation profiling**
+
+ETSI TS 119 472-2 separates:
+
+- an **ISO/IEC-mdoc profile** (clause 5) for proximity-based non-API-mediated device retrieval built on ISO/IEC 18013-5, and
+- an **OpenID4VC-HAIP-based profile** (clause 6) for API-mediated and non-API-mediated transmission.
+
+Within the ETSI OpenID4VC-HAIP profile, non-API-mediated transmission is profiled primarily for SD-JWT VC. ISO mdoc presentation over the HAIP profile is profiled by ETSI only via the API-mediated (DC API) mechanism. Non-API-mediated remote mdoc presentation using redirect-based OpenID4VP is defined by ISO/IEC TS 18013-7, not by ETSI TS 119 472-2 or OpenID4VC-HAIP.
+
+This RFC addresses this gap by defining two tracks:
+
+- **SD-JWT VC track**: applies the ETSI-aligned OpenID4VC-HAIP request and response constraints for non-API-mediated presentation as defined by this RFC.
+- **ISO/IEC 18013-7 remote mdoc track**: defines a dedicated ISO/IEC TS 18013-7-aligned presentation mode for remote `mso_mdoc` presentation with format-specific invocation, request, session binding, response, and validation rules. ETSI-aligned request-object and response-protection requirements are additionally applied to the extent compatible with the ISO/IEC 18013-7-aligned flow.
+
+This RFC does **not** reproduce the ETSI clause 5 ISO/IEC-mdoc proximity profile, since full ISO/IEC 18013-5 proximity device retrieval profiling is out of scope here. This RFC also currently specifies only non-API-mediated presentation mechanisms. API-mediated mechanisms are not specified in this version and may be added in future revisions if required by use cases. For clarity, ETSI clause 5 proximity presentation uses the `RequestInfo` parameter to transport verifier registration certificate material or registrar information to the Wallet. This RFC acknowledges that ETSI mechanism, but does not normatively profile `RequestInfo` processing in this version because the full ISO/IEC 18013-5 proximity flow is out of scope.
+
+### **5.6 ISO/IEC 18013-7 remote mdoc profile**
+
+This RFC defines an ISO/IEC TS 18013-7-aligned profile for remote presentation of `mso_mdoc` credentials over OpenID4VP.
+
+**Accuracy note on protocol lineage.**
+This RFC uses OpenID4VP v1.0 as the baseline presentation protocol.
+For remote `mso_mdoc` presentation, however, ISO/IEC TS 18013-7 Annex B was defined against an earlier OpenID4VP draft lineage.
+Accordingly, the ISO/IEC 18013-7 remote mdoc track in this RFC SHALL be understood as an ISO-aligned compatibility profile implemented using the mdoc-specific OpenID4VP processing rules preserved in later drafts and OpenID4VP v1.0, rather than as a claim that ISO/IEC TS 18013-7 itself was authored against the final OpenID4VP v1.0 specification.
+
+Under this profile:
+
+- the Wallet is invoked using the `mdoc-openid4vp://` scheme for same-device remote presentation
+- the <protocols:Presentation Request> uses `format = mso_mdoc` and identifies the requested document type, <credentials:Namespace|namespaces>, and data elements compatible with ISO mdoc processing
+- the <protocols:Presentation Request> is obtained using `request_uri`
+- the <protocols:Presentation Request> includes the <protocols:Nonce|nonce> and verifier identity inputs needed to construct the ISO-linked `SessionTranscript`
+- the Wallet constructs the `SessionTranscript` using the OpenID4VP-to-ISO handover mapping defined for remote mdoc presentation
+- the `vp_token` carries the base64url-encoded ISO `DeviceResponse` CBOR structure
+- the Wallet binds the returned `DeviceResponse` to the originating request through the `SessionTranscript`
+- the <roles:Verifier> reconstructs and validates the same `SessionTranscript` inputs when validating the returned mdoc presentation
+- the <roles:Verifier> performs ISO-bound validation of the `DeviceResponse`, including document type match, <credentials:Namespace|namespace> and element consistency, <protocols:Nonce|nonce> and handover consistency, and cryptographic validation against the reconstructed session context
+- encrypted response protection is applied using an encrypted response mode supported by the selected OpenID4VP mdoc profile
+
+This profile is distinct from the generic APTITUDE OpenID4VP baseline used for SD-JWT VC. Implementations claiming ISO/IEC 18013-7 alignment for remote mdoc presentation SHALL conform to the requirements defined under this track.
+
+---
+
+## **6\. High-Level Flows**
+
+### **6.1 Same-Device Presentation Flow**
+
+#### **6.1.1 Presentation Request Creation**
+
+The <roles:Verifier> prepares a <protocols:Presentation Request> containing the information needed by the Wallet to determine what credentials and claims are requested, along with the parameters needed to produce a valid response.
+
+The request SHOULD include, as applicable:
+
+- verifier identifier  
+- <protocols:Nonce|nonce>  
+- audience or equivalent recipient binding  
+- requested credential types or claims  
+- disclosure constraints  
+- response endpoint information  
+- validity and expiry parameters
+
+Where the selected profile requires signed requests, the <protocols:Presentation Request> SHALL be integrity protected.
+
+#### **6.1.2 Wallet Invocation**
+
+For the **SD-JWT VC track**, the Wallet is invoked using a supported same-device method, such as:
+
+- an app-to-app link  
+- a deep link  
+- a platform-supported wallet invocation mechanism  
+- another interoperable wallet invocation approach supported by the ecosystem
+
+Where an ETSI-aligned same-device authorization endpoint is used by the applying profile, Wallets and <roles:Verifier|Verifiers> SHOULD support invocation through the `eu-eaap://` scheme.
+
+For the **ISO/IEC 18013-7 remote mdoc track**, same-device wallet invocation SHALL use the `mdoc-openid4vp://` scheme as required by the ISO-aligned profile defined in Section 5.6.
+
+#### **6.1.3 Wallet Validation**
+
+The Wallet SHALL validate the received <protocols:Presentation Request> before presenting it to the <roles:Holder>.
+
+Validation SHOULD include, as applicable:
+
+- request syntax and completeness  
+- signature or integrity protection, where present or required  
+- <protocols:Nonce|nonce> presence and freshness  
+- audience or recipient binding  
+- expiry validity  
+- supported credential query semantics  
+- compatibility with the Wallet’s supported credential formats
+
+Invalid or malformed requests SHALL be rejected.
+
+#### **6.1.4 Holder Consent**
+
+The Wallet SHALL present the request information to the <roles:Holder> in a transparent way.
+
+The Wallet SHOULD display, where applicable:
+
+- the <roles:Verifier> identity  
+- the purpose or context of the request  
+- the requested credential(s)  
+- the requested claims or attributes  
+- selective disclosure details, where supported
+
+The <roles:Holder> SHALL explicitly approve the release before a presentation is generated.
+
+#### **6.1.5 Presentation Generation**
+
+After consent, the Wallet generates the presentation response in accordance with OpenID4VP and the credential format in use.
+
+For the **SD-JWT VC track**, this MAY include:
+
+- a `vp_token`  
+- one or more verifiable presentations or credential-derived proofs  
+- disclosures, where selective disclosure is supported  
+- holder-binding or <protocols:Proof-of-possession|proof-of-possession> material, where required  
+- <protocols:Nonce|nonce> and audience binding data
+
+For the **ISO/IEC 18013-7 remote mdoc track**, the Wallet SHALL:
+
+- construct the `SessionTranscript` using the OpenID4VP-to-ISO handover mapping defined for remote mdoc presentation
+- generate an ISO `DeviceResponse` CBOR structure bound to the originating request through the `SessionTranscript`
+- encode the `DeviceResponse` as a base64url string and place it in the `vp_token`
+
+#### **6.1.6 Presentation Submission**
+
+The Wallet submits the presentation response to the <roles:Verifier> using the response mechanism defined by the request and supported by the protocol.
+
+Submission MAY be direct from the Wallet to the <roles:Verifier> backend or may involve an intermediate browser or platform handoff, depending on the flow.
+
+#### **6.1.7 Result Handling**
+
+The <roles:Verifier> validates the response and returns an outcome.
+
+The outcome SHOULD clearly indicate:
+
+- successful verification  
+- verification failure  
+- user cancellation  
+- unsupported request or unsupported credential format  
+- expired or invalid request  
+- other protocol or validation errors
+
+The Wallet and/or relying application SHOULD display an understandable outcome to the <roles:Holder>.
+
+---
+
+### **6.2 Cross-Device Presentation Flow (Non-API-mediated)**
+
+Cross-device presentation as defined in this section applies to the **SD-JWT VC track**. The ISO/IEC 18013-7 remote mdoc track does not define cross-device presentation under this RFC. If cross-device mdoc presentation is required in future, it SHALL be described as a separate profile claim.
+
+#### **6.2.1 Presentation Request Creation and Display**
+
+The <roles:Verifier> creates the <protocols:Presentation Request> and makes it available through a non-API-mediated cross-device transfer mechanism, typically by encoding reference data or invocation data in a QR code or equivalent.
+
+#### **6.2.2 Wallet Invocation via QR, Link, or Equivalent**
+
+The <roles:Holder> uses a second device to invoke the Wallet and retrieve the <protocols:Presentation Request>.
+
+APTITUDE requires support for cross-device presentation through non-API-mediated interoperable means such as:
+
+- QR-based transfer  
+- link-based transfer  
+- other supported wallet invocation methods
+
+This section does not define API-mediated cross-device presentation. API-mediated approaches (for example, DC API-based flows) may be specified in future RFC revisions where required by agreed use cases.
+
+#### **6.2.3 Wallet Validation**
+
+The same validation rules as in Section 6.1.3 apply.
+
+#### **6.2.4 Holder Consent**
+
+The same holder consent requirements as in Section 6.1.4 apply.
+
+#### **6.2.5 Presentation Generation**
+
+The same presentation generation requirements as in Section 6.1.5 apply.
+
+#### **6.2.6 Presentation Submission**
+
+The Wallet submits the presentation response to the <roles:Verifier> using the mechanism defined by the request and supported by the verifier.
+
+#### **6.2.7 Result Handling**
+
+The <roles:Verifier> validates the presentation and returns the outcome to the relying application and/or Wallet, as appropriate for the flow.
+
+---
+
+## **7\. Normative Requirements**
+
+### **7.1 Wallet Requirements**
+
+A Wallet conforming to this RFC SHALL:
+
+**APT-PRES-WALLET-01**  
+Support OpenID4VP v1.0 for credential presentation.
+
+**APT-PRES-WALLET-02**  
+Support same-device presentation flows for the non-API-mediated mechanisms specified by this RFC.
+
+**APT-PRES-WALLET-03**  
+Support cross-device presentation flows for the non-API-mediated mechanisms specified by this RFC.
+
+**APT-PRES-WALLET-04**  
+Support invocation through interoperable methods suitable for the deployment context, including QR and/or link-based invocation where applicable.
+
+For ETSI-aligned same-device presentation flows that use authorization-endpoint based invocation, a Wallet SHOULD support the `eu-eaap://` scheme.
+
+**APT-PRES-WALLET-05**  
+Validate the <protocols:Presentation Request> before presenting it to the <roles:Holder>.
+
+**APT-PRES-WALLET-06**  
+Reject malformed, expired, or otherwise invalid <protocols:Presentation Request|Presentation Requests>.
+
+**APT-PRES-WALLET-07**  
+Present the requested credential and claim release information to the <roles:Holder> in a transparent way.
+
+**APT-PRES-WALLET-08**  
+Require explicit <roles:Holder> consent before releasing data.
+
+**APT-PRES-WALLET-09**  
+Generate a presentation response conforming to OpenID4VP and the relevant credential format in use.
+
+**APT-PRES-WALLET-10**  
+Bind the response to the request parameters, including <protocols:Nonce|nonce> and audience or equivalent recipient binding, where required by the selected profile or format.
+
+**APT-PRES-WALLET-11**  
+Submit the presentation response to the <roles:Verifier> endpoint indicated by the request or profile.
+
+**APT-PRES-WALLET-12**  
+Support selective disclosure where the credential format in use supports it.
+
+A Wallet conforming to this RFC SHALL NOT:
+
+**APT-PRES-WALLET-13**  
+Accept invalid or unsupported requests without clear error handling.
+
+**APT-PRES-WALLET-14**  
+Release claims not requested by the <roles:Verifier>, unless explicitly authorised by the <roles:Holder> and permitted by the applicable profile.
+
+**APT-PRES-WALLET-15**  
+Perform silent or automatic consent for requests that require user approval.
+
+A Wallet claiming conformance to the **ISO/IEC 18013-7 remote mdoc track** SHALL additionally:
+
+**APT-PRES-WALLET-MDOC-01**  
+Support wallet invocation using the `mdoc-openid4vp://` scheme for same-device remote mdoc presentation.
+
+**APT-PRES-WALLET-MDOC-02**  
+Support retrieval of the <protocols:Presentation Request> using the `request_uri` parameter for the ISO-aligned remote mdoc flow.
+
+**APT-PRES-WALLET-MDOC-03**  
+Construct the `SessionTranscript` using the OpenID4VP-to-ISO handover mapping defined for remote mdoc presentation.
+
+**APT-PRES-WALLET-MDOC-04**  
+Generate an ISO `DeviceResponse` CBOR structure in response to a valid `mso_mdoc` <protocols:Presentation Request>.
+
+**APT-PRES-WALLET-MDOC-05**  
+Bind the returned `DeviceResponse` to the originating request through the `SessionTranscript`.
+
+**APT-PRES-WALLET-MDOC-06**  
+Encode the `DeviceResponse` as a base64url string and place it in the `vp_token`.
+
+**APT-PRES-WALLET-MDOC-07**  
+Encrypt the presentation response using an encrypted response mode supported by the selected OpenID4VP mdoc profile.
+
+---
+
+### **7.2 Verifier Requirements**
+
+A <roles:Verifier> conforming to this RFC SHALL:
+
+**APT-PRES-VER-01**  
+Support OpenID4VP v1.0 for credential presentation requests and responses.
+
+**APT-PRES-VER-02**  
+Support same-device presentation flows for the non-API-mediated mechanisms specified by this RFC.
+
+**APT-PRES-VER-03**  
+Support cross-device presentation flows for the non-API-mediated mechanisms specified by this RFC.
+
+**APT-PRES-VER-04**  
+Create a <protocols:Presentation Request> containing the parameters necessary for the Wallet to process the request.
+
+**APT-PRES-VER-05**  
+Use a <protocols:Nonce|nonce> or equivalent anti-replay mechanism.
+
+**APT-PRES-VER-06**  
+Use audience or recipient binding where required by the selected profile.
+
+**APT-PRES-VER-07**  
+Provide a response endpoint or equivalent response handling mechanism.
+
+**APT-PRES-VER-08**  
+Validate all received presentation responses before relying on them.
+
+**APT-PRES-VER-09**  
+Validate, as applicable:
+
+- request-response correlation  
+- <protocols:Nonce|nonce> binding  
+- audience binding  
+- proof integrity  
+- credential or presentation authenticity  
+- disclosure integrity  
+- holder binding, where required  
+- satisfaction of the requested constraints
+
+**APT-PRES-VER-10**  
+Return a clear outcome indicating success or failure.
+
+**APT-PRES-VER-11**  
+Request only data necessary for the intended purpose.
+
+**APT-PRES-VER-12**  
+Support interoperable invocation methods for both same-device and cross-device non-API-mediated presentation.
+
+For ETSI-aligned same-device presentation flows that use authorization-endpoint based invocation, a <roles:Verifier> SHOULD support the `eu-eaap://` scheme.
+
+A <roles:Verifier> conforming to this RFC SHALL additionally apply the ETSI-aligned request requirements for the flows in scope:
+
+**APT-PRES-VER-13**  
+Use signed request objects.
+
+**APT-PRES-VER-14**  
+Include and publish structured verifier metadata required by the applying profile, including `verifier_info`, RP-registrar/registry-related data, and `client_metadata` verifier key material.
+
+A <roles:Verifier> claiming conformance to the **ISO/IEC 18013-7 remote mdoc track** SHALL additionally:
+
+**APT-PRES-VER-MDOC-01**  
+Construct the <protocols:Presentation Request> using `format = mso_mdoc` and identify the requested document type.
+
+**APT-PRES-VER-MDOC-02**  
+Identify requested data elements using <credentials:Namespace|namespace> and element identifiers compatible with ISO mdoc processing.
+
+**APT-PRES-VER-MDOC-03**  
+Make the <protocols:Presentation Request> available using the `request_uri` parameter for the ISO-aligned remote mdoc flow.
+
+**APT-PRES-VER-MDOC-04**  
+Include in the request the <protocols:Nonce|nonce> and verifier identity inputs needed to construct the ISO-linked `SessionTranscript`.
+
+**APT-PRES-VER-MDOC-05**  
+Provide the parameters needed for the Wallet to encrypt the response under the selected OpenID4VP mdoc profile.
+
+**APT-PRES-VER-MDOC-06**  
+Validate the received `DeviceResponse` presence and format.
+
+**APT-PRES-VER-MDOC-07**  
+Validate document type match between the request and the returned `DeviceResponse`.
+
+**APT-PRES-VER-MDOC-08**  
+Validate <credentials:Namespace|namespace> and requested element consistency between the request and the returned data.
+
+**APT-PRES-VER-MDOC-09**  
+Validate request-response correlation, including <protocols:Nonce|nonce> and handover consistency.
+
+**APT-PRES-VER-MDOC-10**  
+Reconstruct the `SessionTranscript` and validate the cryptographic binding of the returned mdoc presentation object against the reconstructed session context.
+
+A <roles:Verifier> conforming to this RFC SHALL NOT:
+
+**APT-PRES-VER-15**  
+Disable <protocols:Nonce|nonce> validation where <protocols:Nonce|nonce> usage is required.
+
+**APT-PRES-VER-16**  
+Request unnecessary personal data beyond the needs of the use case.
+
+---
+
+## **8\. Interface Definitions**
+
+### **8.1 Wallet Invocation Interface**
+
+**Direction:** <roles:Verifier> → Wallet  
+**Purpose:** Invoke a Wallet for presentation
+
+For the **SD-JWT VC track**, APTITUDE does not mandate a single invocation mechanism across all pilots. Implementations SHALL support interoperable invocation methods appropriate to the use case and deployment context.
+
+Supported invocation methods for the SD-JWT VC track MAY include:
+
+- QR codes  
+- HTTPS links  
+- deep links  
+- custom URI schemes  
+- platform wallet invocation methods
+
+Where a custom URI scheme is used, it SHOULD be documented by the implementation profile applying this RFC. For ETSI-aligned authorization-endpoint invocation, implementations SHOULD support the `eu-eaap://` scheme where that scheme is used by the applying profile.
+
+For the **ISO/IEC 18013-7 remote mdoc track**, wallet invocation SHALL use the `mdoc-openid4vp://` scheme when the requested credential format is `mso_mdoc` under the ISO-aligned profile. The generic invocation methods listed above are not sufficient as the sole rule for ISO remote mdoc presentation.
+
+---
+
+### **8.2 Presentation Request Interface**
+
+The <protocols:Presentation Request> SHALL contain sufficient information for the Wallet to:
+
+- identify the <roles:Verifier>  
+- understand what credential(s) or claim(s) are being requested  
+- determine where and how to submit the response  
+- bind the response to the request  
+- determine whether the request is still valid
+
+At baseline RFC level, the <protocols:Presentation Request> SHALL include, as applicable to the selected OpenID4VP flow and credential format:
+
+- `client_id` or equivalent verifier identifier
+- `nonce`
+- `aud`, where audience restriction is required by the selected profile
+- response endpoint information or equivalent response handling information
+- credential query parameters
+- proof or proof-binding requirements, where required by the selected profile or format
+- expiry or equivalent request validity constraints
+- integrity protection, where required by the selected profile
+
+Where a signed <protocols:Request Object> is used, the <protocols:Request Object> SHOULD contain all parameters necessary for the Wallet to process the request in a self-contained and integrity-protected manner.
+
+Within the ETSI-aligned scope of this RFC, `client_id` SHALL use the Client Identifier Prefix `x509_hash`.
+
+For the non-API-mediated ETSI-aligned presentation flows in scope for this RFC, the Authorization Request SHALL contain the `request_uri` parameter and therefore SHALL NOT carry the <protocols:Request Object> by value.
+
+#### **8.2.1 Baseline structural requirements**
+
+A <protocols:Presentation Request> conforming to this RFC SHOULD be structured so that the Wallet can obtain, either directly from the request or from referenced metadata:
+
+- a verifier identifier
+- a user-displayable verifier name or service description
+- the purpose of the request
+- the privacy-policy reference applicable to the request
+- the set of requested credential types, claims, or constraints
+- the response destination or response mode
+- replay-protection inputs such as <protocols:Nonce|nonce> and request validity period
+
+At baseline RFC level, these structural elements are included to support interoperability, request processing, and user transparency. Their presence does **not** by itself establish verifier registration status, legal reliance, or trustworthiness.
+
+#### **8.2.2 ETSI-aligned request-object requirements**
+
+The <protocols:Presentation Request> SHALL use a signed <protocols:Request Object> with structured verifier data.
+
+The <protocols:Request Object> SHALL include:
+
+- `client_id` (using the Client Identifier Prefix `x509_hash`)
+- `aud`
+- `nonce`
+- `client_metadata`, including verifier key material
+- `verifier_info`
+- the credential request/query parameters
+- response-mode and response-destination parameters as required by the selected flow
+
+`verifier_info` SHALL carry structured verifier information sufficient for the Wallet to present meaningful request context to the <roles:Holder>. Such information SHALL include, where available:
+
+- verifier identifier
+- service description
+- RP-registrar registry or information-service URI
+- verifier registration certificate or equivalent registrar-issued verifier evidence
+- intended-use identifier
+- purpose information
+- privacy-policy URI
+- optionally, credential- or claim-related request context
+
+For remote ETSI-aligned presentation flows, `verifier_info` SHALL be the container used to transport verifier registration certificate material or registrar information when such information is required by the applying profile.
+
+If an ecosystem profile defines verifier registration certificates or equivalent verifier evidence, such evidence MAY be carried as an additional structured verifier-information element.
+
+If `client_metadata` contains `jwks`, each key intended for request-object verification SHALL include `kid` and `use` values sufficient for the Wallet to identify the intended verifier signing key unambiguously.
+
+This RFC does **not** define, at baseline level:
+
+- verifier registration governance
+- mandatory registrar APIs
+- registration-certificate validation rules
+- trusted-list processing rules
+- trust-anchor distribution mechanisms
+- legal meaning of verifier registration status
+
+Those aspects MAY be defined by a future APTITUDE trust framework, by a sectoral deployment profile, or by an ecosystem profile applied together with this RFC.
+
+#### **8.2.3 Credential-format considerations**
+
+For **SD-JWT VC** requests, the <protocols:Presentation Request> SHOULD identify the requested credential type and requested disclosures or constraints in a way consistent with the selected OpenID4VP query mechanism and profile.
+
+#### **8.2.3.1 ISO/IEC 18013-7 remote mdoc request requirements**
+
+For the **ISO/IEC 18013-7 remote mdoc track**, the <protocols:Presentation Request> SHALL:
+
+- use `format = mso_mdoc`
+- identify the requested document type
+- identify requested data elements using <credentials:Namespace|namespace> and element identifiers compatible with ISO mdoc processing
+- be obtained using `request_uri` for the ISO-aligned remote flow
+- include the <protocols:Nonce|nonce> and verifier identity inputs needed to construct the ISO-linked `SessionTranscript`
+- include in `verifier_info`, where required by the applying profile, verifier registration certificate material or registrar information needed by the Wallet
+
+The <protocols:Presentation Request> for remote mdoc presentation SHALL use the DCQL query mechanism with the ISO mdoc credential format specific parameters as defined by OpenID4VP.
+
+#### **8.2.4 Request validation expectations**
+
+The Wallet SHALL reject a <protocols:Presentation Request> that is malformed, expired, missing required anti-replay inputs, or otherwise inconsistent with the selected profile.
+
+Where signed <protocols:Request Object|Request Objects> are used, the Wallet SHALL validate the integrity of the <protocols:Request Object> before relying on its contents.
+
+The Wallet SHALL validate the structured verifier information and verifier signing material according to the ETSI-aligned rules applied by this RFC.
+
+#### **8.2.5 ISO/IEC 18013-7 session binding**
+
+For the **ISO/IEC 18013-7 remote mdoc track**, this RFC defines the following normative session-binding requirements:
+
+- the Wallet SHALL construct the `SessionTranscript` using the OpenID4VP-to-ISO handover mapping defined for remote mdoc presentation
+- the Wallet SHALL bind the returned `DeviceResponse` to the originating request through the `SessionTranscript`
+- the <roles:Verifier> SHALL reconstruct and validate the same `SessionTranscript` inputs when validating the returned mdoc presentation
+
+The `SessionTranscript` provides the core ISO security binding for remote mdoc presentation. Without correct construction and validation of the `SessionTranscript`, the presentation cannot be considered bound to the originating request and the <roles:Verifier> session context.
+
+---
+
+### **8.3 Presentation Response Interface**
+
+**Direction:** Wallet → <roles:Verifier>  
+**Method:** As defined by the selected OpenID4VP flow and profile
+
+The Presentation Response SHALL contain the payload, proof material, and correlation inputs required for the <roles:Verifier> to:
+
+- associate the response with the originating request
+- determine which requested credential(s) or claim(s) are being returned
+- validate the authenticity and integrity of the presentation
+- validate replay-protection and recipient-binding inputs, where required
+- determine whether the response satisfies the request constraints
+
+At baseline RFC level, the Presentation Response SHALL include the elements required by the selected OpenID4VP flow, response mode, and credential format.
+
+Typical response elements MAY include:
+
+- `vp_token`
+- `presentation_submission`, where used by the selected profile
+- disclosures, where selective disclosure is supported by the selected credential format
+- proof-binding or holder-binding material, where required
+- `state` or equivalent transaction-correlation data
+- format-specific presentation payloads or derived proof structures
+
+Where the selected flow or profile requires response correlation, the Wallet SHALL return the correlation values required for the <roles:Verifier> to bind the response to the correct transaction context.
+
+#### **8.3.1 Baseline response requirements**
+
+At baseline RFC level, the Presentation Response SHOULD:
+
+- contain only the credential-derived data, disclosures, and proof material necessary to satisfy the request
+- preserve request-response correlation inputs such as `nonce`, `state`, audience binding, or equivalent recipient-binding data, where required by the selected profile
+- avoid returning additional claims or credentials beyond those approved by the <roles:Holder> and required by the request
+- be transmitted using a secure response mechanism appropriate to the selected flow
+
+If the selected credential format supports selective disclosure, the Wallet SHOULD include only the disclosures necessary to satisfy the approved request.
+
+If the selected flow supports multiple response modes, the Wallet SHALL construct the response in the format required by the response mode indicated by the request.
+
+#### **8.3.2 ETSI-aligned response protection**
+
+The Presentation Response SHALL additionally apply stricter response-protection rules.
+
+The following response-protection rules are mandatory:
+
+- encrypted authorization or presentation responses
+- strict audience restriction
+- strong transaction correlation
+- mandatory proof-binding requirements
+- profile-specific response serialization and submission rules
+
+The Wallet SHALL encrypt the response.
+
+For the **ISO/IEC 18013-7 remote mdoc track**, the following additional response-protection rules apply:
+
+- the ISO-aligned mdoc profile SHALL use an encrypted response mode supported by the selected OpenID4VP mdoc profile
+- the <roles:Verifier> SHALL provide the parameters needed for the Wallet to protect the response accordingly
+- the encrypted response SHALL carry the `DeviceResponse` as defined in Section 8.3.3.1
+
+This RFC does **not** define, at baseline level:
+
+- the mandatory response-encryption algorithms
+- mandatory response-encryption key-distribution rules
+- mandatory verifier certificate processing for response encryption
+- trust-framework-specific legal or supervisory effects of successful verifier authentication
+
+Those aspects MAY be defined by a future APTITUDE trust framework, by a sectoral deployment profile, or by an ecosystem profile applied together with this RFC.
+
+#### **8.3.3 Credential-format considerations**
+
+For **SD-JWT VC** presentation, the response SHOULD contain the credential-derived presentation material and only the disclosures necessary to satisfy the approved request, together with any proof-binding material required by the selected profile.
+
+#### **8.3.3.1 ISO/IEC 18013-7 remote mdoc response requirements**
+
+For the **ISO/IEC 18013-7 remote mdoc track**, the `vp_token` SHALL carry the base64url-encoded ISO `DeviceResponse` CBOR structure.
+
+The <roles:Verifier> is not receiving arbitrary document-derived claims. It is receiving a signed or MACed ISO presentation object that SHALL be validated against the originating request context and the reconstructed `SessionTranscript`.
+
+The <roles:Verifier> SHALL validate:
+
+- `DeviceResponse` presence and format
+- document type match between the request and the returned `DeviceResponse`
+- <credentials:Namespace|namespace> and requested element consistency
+- request-response correlation
+- <protocols:Nonce|nonce> and handover consistency
+- cryptographic binding of the returned mdoc presentation object against the reconstructed session context
+
+#### **8.3.4 Error responses**
+
+Where the presentation fails or cannot be completed, the Wallet or response-handling component SHOULD return an error in a machine-readable form and, where appropriate, a human-readable description.
+
+Error conditions MAY include:
+
+- invalid presentation
+- malformed response
+- user cancellation
+- expired request
+- unsupported credential format
+- missing required proof material
+- failed request-response correlation
+- failed verifier-side validation
+
+**Example (non-normative) conceptual success response:**
+
+```json
+{
+  "vp_token": "<presentation-response>",
+  "presentation_submission": "<submission-object>",
+  "state": "<transaction-state>"
+}
+```
+
+**Example (non-normative) conceptual error response:**
+
+```json
+{
+  "error": "invalid_presentation",
+  "error_description": "Presentation validation failed"
+}
+```
+
+---
+
+### **8.4 Verifier Metadata Interface**
+
+The <roles:Verifier> SHOULD publish metadata describing its capabilities and requirements where such metadata is used by the ETSI-aligned flow or by the selected deployment profile.
+
+This MAY include:
+
+- supported presentation formats  
+- supported credential query methods  
+- supported proof mechanisms  
+- verifier signing keys or trust anchors  
+- supported response modes  
+- endpoint information
+
+---
+
+## **9\. Privacy and Security Considerations**
+
+Implementations conforming to this RFC SHOULD follow strong privacy and security practices consistent with OpenID4VP-based presentation flows and with the assurance requirements of the applying deployment profile.
+
+This RFC defines a baseline interoperability profile. It includes structural requirements that support secure processing of presentation requests and responses, but it does **not** by itself define a complete verifier trust framework, verifier registration regime, or trusted-list governance model.
+
+### **9.1 Data minimisation and disclosure control**
+
+<roles:Verifier|Verifiers> SHOULD request only the minimum data necessary for the stated purpose of the transaction.
+
+Wallets SHOULD support selective disclosure where supported by the selected credential format and SHOULD release only the claims, attributes, or credential-derived data necessary to satisfy the approved request.
+
+Implementations SHOULD avoid requesting, presenting, transmitting, or retaining data beyond what is necessary for the use case.
+
+### **9.2 Request authenticity and integrity**
+
+<protocols:Presentation Request|Presentation Requests> SHOULD be protected against tampering.
+
+Where the selected profile or deployment mode uses signed <protocols:Request Object|Request Objects>, the Wallet SHALL validate request integrity before relying on the request contents.
+
+Wallets SHALL reject malformed, expired, or otherwise invalid requests and SHOULD reject requests that lack the anti-replay or correlation inputs required by the selected profile.
+
+At baseline RFC level, structured verifier information and verifier metadata support request processing and user transparency, but do **not** by themselves establish verifier trustworthiness or legal registration status.
+
+### **9.3 Replay protection and transaction binding**
+
+<protocols:Nonce|Nonces>, expiry values, state parameters, audience restriction, and equivalent transaction-binding inputs SHOULD be used where required by the selected flow or credential format in order to reduce replay risk and response misbinding.
+
+Wallets and <roles:Verifier|Verifiers> SHALL preserve the request-response correlation inputs required by the selected response mode and credential format.
+
+Implementations SHOULD ensure that a presentation response cannot be successfully replayed in a different verifier session or redirected to an unintended relying context.
+
+### **9.4 Response confidentiality and secure transport**
+
+Implementers SHALL ensure secure transport for presentation requests, metadata retrieval, response submission, and related endpoint communication.
+
+Response endpoints SHOULD be protected against leakage, downgrade, redirection, and unauthorised access.
+
+Encrypted presentation or authorization responses SHALL be used for the ETSI-aligned presentation flows in scope for this RFC.
+
+This RFC does **not** define, at baseline level, mandatory response-encryption algorithms, key-distribution methods, or verifier-certificate processing rules for encrypted responses.
+
+### **9.5 Verifier impersonation and phishing resistance**
+
+Wallets SHOULD present meaningful verifier information to the <roles:Holder> wherever such information is available.
+
+Cross-device invocation methods and same-device deep-link flows SHOULD minimise phishing, request substitution, and verifier impersonation risks.
+
+Implementations SHOULD ensure that the <roles:Holder> can distinguish the intended <roles:Verifier> or service context before approving release.
+
+Where verifier metadata, structured verifier information, or signed <protocols:Request Object|Request Objects> are available, Wallets SHOULD use them to improve request authenticity checks and user transparency.
+
+### **9.6 Credential-format considerations**
+
+For **SD-JWT VC** presentation, implementations SHOULD preserve the privacy properties of selective disclosure and SHOULD validate any required proof-binding or recipient-binding inputs defined by the selected profile.
+
+For the **ISO/IEC 18013-7 remote mdoc track**, implementations SHALL:
+
+- protect the confidentiality and integrity of the returned `DeviceResponse` using the encrypted response mode defined by the ISO-aligned profile
+- construct and validate the `SessionTranscript` correctly, since the `SessionTranscript` provides the binding between the OpenID4VP request context and the ISO mdoc presentation object
+- validate the cryptographic integrity of the returned mdoc presentation object against the reconstructed `SessionTranscript` before relying on the returned data
+- ensure that the `DeviceResponse` cannot be replayed in a different verifier session or bound to a different request context
+
+Implementations claiming ISO/IEC 18013-7 alignment SHALL NOT treat mdoc presentation as a loosely profiled OpenID4VP format. The ISO session-binding, `DeviceResponse` structure, and cryptographic validation requirements are normative and distinct from the generic SD-JWT VC response processing model.
+
+### **9.7 Logging, retention, and local protection**
+
+Implementations SHOULD avoid logging sensitive presentation contents except where operationally necessary.
+
+Where logs are required for security or troubleshooting purposes, implementations SHOULD minimise retained personal data and protect logs against unauthorised access.
+
+Wallets, <roles:Verifier|Verifiers>, and related backend components SHOULD protect locally stored request, response, session, and metadata artefacts against unauthorised disclosure or modification.
+
+### **9.8 Baseline RFC boundary**
+
+This RFC defines protocol-level privacy and security expectations for interoperable presentation processing.
+
+It does **not** by itself define:
+
+- verifier trust framework governance
+- mandatory verifier registration procedures
+- trusted-list supervision rules
+- sector-specific legal reliance rules
+- mandatory incident-handling obligations
+- full deployment-security controls beyond the protocol boundary
+
+Those aspects MAY be defined by a future APTITUDE trust framework, by a sectoral deployment profile, or by an ecosystem profile applied together with this RFC.
+
+---
+
+## **10\. Conformance**
+
+This RFC defines conformance for interoperable credential presentation and verification in APTITUDE using **OpenID4VP v1.0** across two normative tracks:
+
+- **SD-JWT VC track conformance** — baseline APTITUDE OpenID4VP presentation with ETSI-aligned request, verifier-identification, and response-protection requirements
+- **ISO/IEC 18013-7 remote mdoc track conformance** — ISO/IEC TS 18013-7-aligned presentation of `mso_mdoc` credentials with dedicated invocation, request, session binding, response, and validation requirements
+
+An implementation MAY conform to one or both tracks. Conformance claims SHALL specify which track(s) the implementation supports.
+
+This RFC does **not** require conformance to:
+
+- JSON-LD W3C VC presentation
+- a specific verifier trust framework
+- verifier registration governance
+- trusted-list supervision or trust-anchor governance
+- full ISO/IEC 18013-5 proximity device retrieval profiling
+- sector-specific legal or supervisory rules
+
+Conformance to the SD-JWT VC track includes the ETSI-aligned request, verifier-identification, and response-protection requirements defined for the non-API-mediated presentation flows in scope. Conformance to the ISO/IEC 18013-7 remote mdoc track includes the ISO-specific invocation, request construction, session binding, `DeviceResponse` response structure, and verifier validation requirements defined by this RFC.
+
+### **10.1 Wallet conformance**
+
+#### **10.1.1 SD-JWT VC track wallet conformance**
+
+An implementation conforms to this RFC as a **Wallet** under the **SD-JWT VC track** if it:
+
+1. satisfies all applicable Wallet requirements in Section 7.1 (APT-PRES-WALLET-01 through APT-PRES-WALLET-15)
+2. implements the relevant interfaces in Section 8  
+3. supports OpenID4VP v1.0 presentation processing  
+4. supports the same-device and cross-device presentation flows required by this RFC
+5. supports SD-JWT VC presentation
+6. validates <protocols:Presentation Request|Presentation Requests> before acting on them  
+7. binds presentation responses to the request context where required by the selected profile
+8. submits presentation responses using the response mechanism defined by the request or applying profile
+
+A Wallet conforming to the SD-JWT VC track SHALL conform to the stricter ETSI-aligned request, metadata, and response-protection rules defined by this document for the flows in scope.
+
+#### **10.1.2 ISO/IEC 18013-7 remote mdoc track wallet conformance**
+
+An implementation conforms to this RFC as a **Wallet** under the **ISO/IEC 18013-7 remote mdoc track** if it:
+
+1. satisfies all applicable Wallet requirements in Section 7.1 (APT-PRES-WALLET-01 through APT-PRES-WALLET-15) as applicable to the mdoc flow
+2. satisfies all ISO mdoc wallet requirements (APT-PRES-WALLET-MDOC-01 through APT-PRES-WALLET-MDOC-07)
+3. implements the ISO-aligned interfaces in Section 8, including Section 8.2.3.1, Section 8.2.5, and Section 8.3.3.1
+4. supports same-device remote mdoc presentation using the `mdoc-openid4vp://` scheme
+5. constructs the `SessionTranscript` correctly and binds the `DeviceResponse` to the originating request
+6. generates a valid ISO `DeviceResponse` CBOR structure and encodes it as base64url in the `vp_token`
+7. encrypts the response using the encrypted response mode defined by the ISO-aligned profile
+
+### **10.2 Verifier conformance**
+
+#### **10.2.1 SD-JWT VC track verifier conformance**
+
+An implementation conforms to this RFC as a **<roles:Verifier>** under the **SD-JWT VC track** if it:
+
+1. satisfies all applicable <roles:Verifier> requirements in Section 7.2 (APT-PRES-VER-01 through APT-PRES-VER-16)
+2. implements the relevant interfaces in Section 8  
+3. supports OpenID4VP v1.0 presentation requests and response handling  
+4. supports the same-device and cross-device presentation flows required by this RFC
+5. supports SD-JWT VC presentation
+6. creates <protocols:Presentation Request|Presentation Requests> containing the information necessary for Wallet processing  
+7. validates received presentation responses before relying on them  
+8. enforces request-response correlation, anti-replay, and proof-validation requirements
+
+A <roles:Verifier> conforming to the SD-JWT VC track SHALL conform to the stricter ETSI-aligned request-object, verifier-information, metadata, and response-protection rules defined by this document for the flows in scope.
+
+#### **10.2.2 ISO/IEC 18013-7 remote mdoc track verifier conformance**
+
+An implementation conforms to this RFC as a **<roles:Verifier>** under the **ISO/IEC 18013-7 remote mdoc track** if it:
+
+1. satisfies all applicable <roles:Verifier> requirements in Section 7.2 as applicable to the mdoc flow
+2. satisfies all ISO mdoc verifier requirements (APT-PRES-VER-MDOC-01 through APT-PRES-VER-MDOC-10)
+3. implements the ISO-aligned interfaces in Section 8, including Section 8.2.3.1, Section 8.2.5, and Section 8.3.3.1
+4. constructs the <protocols:Presentation Request> using `format = mso_mdoc` with document type, <credentials:Namespace|namespace>, and element identifiers
+5. makes the request available using `request_uri`
+6. reconstructs the `SessionTranscript` and validates the cryptographic binding of the returned `DeviceResponse`
+7. validates `DeviceResponse` presence, format, document type match, <credentials:Namespace|namespace> and element consistency, <protocols:Nonce|nonce> and handover consistency, and cryptographic integrity
+
+### **10.3 Conformance boundaries**
+
+Conformance to this RFC demonstrates protocol-level interoperability for presentation request processing, Wallet invocation, presentation submission, and verifier-side validation within the scope of the claimed track(s).
+
+Conformance to this RFC does **not** by itself demonstrate:
+
+- compliance with a complete verifier trust framework
+- compliance with ARF/CIR obligations beyond the protocol interoperability scope exercised here
+- compliance with sector-specific supervisory or legal requirements
+- compliance with the full ISO/IEC 18013-5 proximity device retrieval profile (ETSI TS 119 472-2 clause 5)
+- compliance with ETSI requirements that are out of scope for this RFC, including API-mediated flows
+- compliance with ISO/IEC TS 18013-7 requirements beyond the remote presentation scope defined by this RFC
+
+### **10.4 Scope of the conformance matrix**
+
+The conformance matrix defined by this RFC verifies baseline protocol interoperability between the implementation under test and the reference endpoints or reference request/response patterns defined by this APTITUDE Presentation Profile.
+
+It is intended to confirm correct support for representative OpenID4VP v1.0 presentation flows covered by this RFC, including the credential presentation formats and response behaviors in scope for the selected test scenarios.
+
+The matrix is a **protocol interoperability matrix**, not a complete ARF/CIR compliance assessment.
+
+It focuses on:
+
+- presentation request processing
+- Wallet invocation
+- presentation generation and submission
+- request-response correlation
+- verifier-side response validation
+- format-specific interoperability checks for the credential formats in scope
+
+It does **not** exhaustively test broader trust, governance, privacy, supervisory, legal, or deployment-specific obligations.
+
+For avoidance of doubt, the matrix in this version does not exercise ETSI clause 5 proximity `RequestInfo` transport. That ETSI mechanism remains outside the conformance scope of this RFC version.
+
+Where ARF or CIR references are included, they provide traceability and alignment for the interoperability capability being exercised, rather than full normative coverage of the broader requirement domain.
+
+### **10.5 Additional profile-specific conformance claims**
+
+If an implementation claims support for an additional ecosystem profile layered on top of this RFC, that claim SHOULD be stated separately from RFC conformance.
+
+Such additional claims MAY cover:
+
+- signed <protocols:Request Object|Request Objects>
+- structured verifier information
+- verifier metadata requirements
+- encrypted presentation responses
+- stronger proof-binding requirements
+- ecosystem-specific verifier identification rules
+- ecosystem-specific trust or registration processing rules
+
+Those additional claims are outside RFC conformance unless explicitly incorporated into the applying profile and corresponding conformance tests.
+
+---
+
+## 11. Wallet-Under-Test Conformance Catalogue and Deployed Test Matrix
+
+### **11.1 Conformance Check Catalogue**
+
+This catalogue defines the baseline conformance checks that support RFC interoperability claims under Section 10.
+
+#### **11.1.1 Baseline conformance checks**
+
+| Check ID | Conformance Check | What Is Verified At Runtime | ARF / CIR Linkage |
+| --- | --- | --- | --- |
+| `VP-CHECK-01` | Request resolution and processing | The Wallet resolves the request reference and processes the <protocols:Presentation Request> without transport, parsing, or structural failure. | CIR presentation interface support; ARF interoperability baseline |
+| `VP-CHECK-02` | ETSI-aligned verifier identification | The <protocols:Request Object> uses `client_id` with the `x509_hash` Client Identifier Prefix and presents the verifier identifier required by the ETSI-aligned flow. | ARF verifier interoperability; CIR secure presentation interface |
+| `VP-CHECK-03` | Signed <protocols:Request Object> validation | The Wallet validates the signed <protocols:Request Object> and rejects missing, malformed, or unverifiable request-object protection. | ARF request integrity; CIR secure presentation interface |
+| `VP-CHECK-04` | Structured verifier-information processing | The Wallet correctly processes mandatory ETSI-aligned verifier information, including `verifier_info` and required `client_metadata` verifier key material. | ARF verifier transparency and request processing; CIR secure presentation interface |
+| `VP-CHECK-05` | DCQL request satisfaction | The Wallet returns a response matching the requested DCQL credential and claim constraints for the selected credential format and request profile. | ARF controlled attribute presentation; CIR presentation request processing |
+| `VP-CHECK-06` | Response correlation | The <roles:Verifier> can correlate the response to the stored session using response-mode-specific state and transaction context. | CIR secure presentation interface; ARF transaction integrity baseline |
+| `VP-CHECK-07` | <protocols:Nonce> binding | A recoverable `nonce` is present where expected and is preserved consistently across request processing and response validation. | ARF replay protection baseline; CIR secure presentation interface |
+| `VP-CHECK-08` | SD-JWT proof-binding validation | Where SD-JWT proof binding is present, the <roles:Verifier> checks the required recipient-binding and integrity inputs, including `aud` and `sd_hash`, as applicable to the selected profile. | ARF proof binding and recipient restriction; CIR secure presentation interface |
+| `VP-CHECK-09` | Encrypted response handling | The Wallet and <roles:Verifier> apply the mandatory ETSI-aligned response-protection behavior and successfully exchange an encrypted presentation or authorization response. | ARF protected response handling; CIR secure presentation interface |
+| `VP-CHECK-10` | Transaction-data binding | Where transaction data is included, it is preserved and evaluated in the same <roles:Verifier> session context as the credential request. | ARF transaction-aware presentation patterns; CIR secure presentation interface |
+| `VP-CHECK-11` | mdoc `DeviceResponse` validation | For ISO/IEC 18013-7 remote mdoc presentation, the <roles:Verifier> validates `DeviceResponse` presence and format, document type match, <credentials:Namespace\|namespace> and element consistency, request-response correlation, <protocols:Nonce\|nonce> and handover consistency, and cryptographic validation of the returned mdoc presentation object against the reconstructed `SessionTranscript`. | ARF credential-format interoperability; CIR presentation interface support; ISO/IEC TS 18013-7 alignment |
+| `VP-CHECK-12` | Request-URI retrieval | The Wallet successfully retrieves and processes the <protocols:Presentation Request> using the `request_uri` parameter, as required by the ETSI-aligned non-API-mediated flow and the ISO/IEC 18013-7-aligned remote mdoc flow. | ARF request transfer/interoperability; CIR presentation interface support |
+| `VP-CHECK-17` | ETSI authorization-endpoint invocation | Where the deployed ETSI-aligned same-device flow uses authorization-endpoint invocation, the Wallet and <roles:Verifier> correctly invoke and process the request using the `eu-eaap://` scheme. | ETSI-aligned invocation interoperability; CIR presentation interface support |
+| `VP-CHECK-18` | Remote verifier registration information transport | For ETSI-aligned remote presentation flows that require verifier registration material, the <protocols:Request Object> carries that material in `verifier_info` and the Wallet processes it as verifier context. | ETSI verifier transparency; CIR secure presentation interface |
+| `VP-CHECK-13` | ISO mdoc invocation method | The Wallet is invoked using the `mdoc-openid4vp://` scheme for same-device remote mdoc presentation under the ISO/IEC 18013-7-aligned profile. | ISO/IEC TS 18013-7 alignment; ARF wallet invocation interoperability |
+| `VP-CHECK-14` | ISO mdoc request structure | The <protocols:Presentation Request> uses `format = mso_mdoc`, identifies the requested document type, and specifies <credentials:Namespace\|namespace> and element identifiers compatible with ISO mdoc processing. | ISO/IEC TS 18013-7 alignment; ARF request interoperability |
+| `VP-CHECK-15` | ISO `SessionTranscript` binding | The Wallet constructs the `SessionTranscript` using the OpenID4VP-to-ISO handover mapping, and the <roles:Verifier> reconstructs and validates the same `SessionTranscript` inputs. The `DeviceResponse` is cryptographically bound to the originating request through the `SessionTranscript`. | ISO/IEC TS 18013-7 alignment; ARF session integrity |
+| `VP-CHECK-16` | ISO mdoc encrypted response | The Wallet encrypts the mdoc presentation response using an encrypted response mode supported by the selected OpenID4VP mdoc profile. The <roles:Verifier> successfully decrypts and processes the response. | ISO/IEC TS 18013-7 alignment; ARF protected response handling |
+
+### 11.2 Deployed Test Case Matrix
+
+| Test Case ID | Deployed Scenario | Request Profile / Variant | Checks Covered | Expected Outcome |
+| --- | --- | --- | --- | --- |
+| `VP-001` | DCQL-based Verifiable Presentation request for `urn:eu.europa.ec.eudi:pid:1` with `family_name` claim, `x509_hash` `client_id`, signed <protocols:Request Object>, mandatory verifier information, and encrypted response | PID / SD-JWT ETSI-aligned selective-claim request | `VP-CHECK-01`, `VP-CHECK-02`, `VP-CHECK-03`, `VP-CHECK-04`, `VP-CHECK-05`, `VP-CHECK-06`, `VP-CHECK-07`, `VP-CHECK-08`, `VP-CHECK-09` | Successful completion of the ETSI-aligned PID / `family_name` presentation session |
+| `VP-002` | DCQL-based Verifiable Presentation request for `urn:eu.europa.ec.eudi:pid:1` with `family_name` claim using a second ETSI-aligned request variant | Second deployed PID / SD-JWT ETSI-aligned selective-claim variant | `VP-CHECK-01`, `VP-CHECK-02`, `VP-CHECK-03`, `VP-CHECK-04`, `VP-CHECK-05`, `VP-CHECK-06`, `VP-CHECK-07`, `VP-CHECK-08`, `VP-CHECK-09` | Successful completion of the ETSI-aligned PID / `family_name` presentation session |
+| `VP-003` | DCQL-based Verifiable Presentation request for `urn:eu.europa.ec.eudi:pid:1` with `family_name` claim using a third ETSI-aligned request variant | Third deployed PID / SD-JWT ETSI-aligned selective-claim variant | `VP-CHECK-01`, `VP-CHECK-02`, `VP-CHECK-03`, `VP-CHECK-04`, `VP-CHECK-05`, `VP-CHECK-06`, `VP-CHECK-07`, `VP-CHECK-08`, `VP-CHECK-09` | Successful completion of the ETSI-aligned PID / `family_name` presentation session |
+| `VP-004` | DCQL-based Verifiable Presentation request for `urn:eu.europa.ec.eudi:pid:1` with `family_name` claim and transaction data, using ETSI-aligned verifier identification, signed <protocols:Request Object>, and encrypted response | PID / SD-JWT ETSI-aligned request with transaction data | `VP-CHECK-01`, `VP-CHECK-02`, `VP-CHECK-03`, `VP-CHECK-04`, `VP-CHECK-05`, `VP-CHECK-06`, `VP-CHECK-07`, `VP-CHECK-08`, `VP-CHECK-09`, `VP-CHECK-10` | Successful completion of the ETSI-aligned transaction-data PID presentation session |
+| `VP-005` | DCQL-based VP request for `urn:eu.europa.ec.eudi:pid:1`, `x509_hash` `client_id`, signed <protocols:Request Object>, structured verifier information, and encrypted response | PID / SD-JWT ETSI-aligned request and response | `VP-CHECK-01`, `VP-CHECK-02`, `VP-CHECK-03`, `VP-CHECK-04`, `VP-CHECK-05`, `VP-CHECK-06`, `VP-CHECK-07`, `VP-CHECK-08`, `VP-CHECK-09` | Successful completion of the ETSI-aligned PID presentation session |
+| `VP-006` | DCQL-based Verifiable Presentation request for `urn:eu.europa.ec.eudi:pid:1`, `x509_hash` `client_id`, signed <protocols:Request Object>, structured verifier information, encrypted response, and `request_uri`-based request retrieval | PID / SD-JWT ETSI-aligned request retrieval variant | `VP-CHECK-01`, `VP-CHECK-02`, `VP-CHECK-03`, `VP-CHECK-04`, `VP-CHECK-05`, `VP-CHECK-06`, `VP-CHECK-07`, `VP-CHECK-08`, `VP-CHECK-09`, `VP-CHECK-12` | Successful completion of the ETSI-aligned PID presentation session using `request_uri` retrieval |
+| `VP-006A` | ETSI-aligned same-device <protocols:Presentation Request> using authorization-endpoint invocation with the `eu-eaap://` scheme | PID / SD-JWT ETSI-aligned same-device authorization-endpoint invocation variant | `VP-CHECK-01`, `VP-CHECK-02`, `VP-CHECK-03`, `VP-CHECK-04`, `VP-CHECK-09`, `VP-CHECK-17` | Successful completion of the ETSI-aligned PID presentation session using `eu-eaap://` invocation |
+| `VP-007` | ISO/IEC 18013-7-aligned remote mdoc <protocols:Presentation Request> for `urn:eu.europa.ec.eudi:pid:1:mso_mdoc`, using `mdoc-openid4vp://` invocation, `format = mso_mdoc`, `request_uri`-based request retrieval, `verifier_info`-carried verifier registration material where required, `SessionTranscript` binding, base64url-encoded `DeviceResponse` in `vp_token`, encrypted response, and ISO-bound verifier validation | ISO/IEC 18013-7-aligned remote mdoc presentation with `DeviceResponse` validation, `SessionTranscript` binding, verifier registration-information transport, and encrypted response protection | `VP-CHECK-01`, `VP-CHECK-06`, `VP-CHECK-07`, `VP-CHECK-11`, `VP-CHECK-12`, `VP-CHECK-13`, `VP-CHECK-14`, `VP-CHECK-15`, `VP-CHECK-16`, `VP-CHECK-18` | Successful completion of the ISO/IEC 18013-7-aligned remote mdoc presentation session |
+
+## **12\. References**
+
+1. OpenID Foundation, *OpenID for Verifiable Presentations 1.0*  
+2. OpenID Foundation, *OpenID4VC High Assurance Interoperability Profile (HAIP) 1.0*  
+3. Architecture and Reference Framework (ARF)  
+4. APTITUDE interoperability and conformance testing materials  
+5. WE BUILD Credential Presentation conformance specification used as structural reference for this RFC draft
+6. ETSI TS 119 472-2 V1.2.1 (2026-03), *Electronic Signatures and Trust Infrastructures (ESI); Profiles for Electronic Attestation of Attributes; Part 2: Profiles for EAA/PID Presentations to Relying Party*
+7. ISO/IEC TS 18013-7:2025, *Personal identification — ISO-compliant driving licence — Part 7: Mobile driving licence (mDL) add-on functions*
+8. ISO/IEC 18013-5:2021, *Personal identification — ISO-compliant driving licence — Part 5: Mobile driving licence (mDL) application*

--- a/docs/horizontal-RFCs/index.md
+++ b/docs/horizontal-RFCs/index.md
@@ -1,0 +1,8 @@
+# RFCs (Request for Comments)
+
+This section contains the Request for Comments (RFCs) that define the technical profiles and specifications for the APTITUDE pilot.
+
+| Document | Description |
+|----------|-------------|
+| [RFC-01 Credential Issuance Profile](RFC001.md) | Defines the credential issuance flow and baseline specifications for APTITUDE pilots |
+| [RFC-02 Presentation Profile](RFC002.md) | Defines the credential presentation and verification flow for APTITUDE pilots |

--- a/docs/rulebook/index.md
+++ b/docs/rulebook/index.md
@@ -1,0 +1,8 @@
+# Attestation Rulebooks
+
+This section contains the official attestation rulebooks for the APTITUDE project.
+
+| Document | Description |
+|----------|-------------|
+| [mVRC Rulebook](wp5/mVRC-rulebook.md) | Attestation Rulebook for attestations of type EU-mVRC |
+| [Trust Framework Rulebook](wp2-trust-specifications/deliverable-2.1-trust.md) | Implementation Profiles for the Trust Framework |

--- a/docs/rulebook/index.md
+++ b/docs/rulebook/index.md
@@ -4,5 +4,5 @@ This section contains the official attestation rulebooks for the APTITUDE projec
 
 | Document | Description |
 |----------|-------------|
-| [mVRC Rulebook](wp5/mVRC-rulebook.md) | Attestation Rulebook for attestations of type EU-mVRC |
+| [mVRC Rulebook](mVRC-rulebook.md) | Attestation Rulebook for attestations of type EU-mVRC |
 | [Trust Framework Rulebook](wp2-trust-specifications/deliverable-2.1-trust.md) | Implementation Profiles for the Trust Framework |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,10 @@ plugins:
       glob:
         - 'rulebook/wp2-trust-specifications/README.md'
         - 'rulebook/wp2-trust-specifications/CONTRIBUTING.md'
+        - 'rulebook/wp2-trust-specifications/terminology.md'
+        - 'rulebook/wp2-trust-specifications/references/**'
+        - 'rulebook/wp2-trust-specifications/requirements/**'
+        - 'rulebook/wp2-trust-specifications/topics/**'
   - search
   - ezglossary:
       strict: true
@@ -72,7 +76,6 @@ plugins:
         - components
         - credentials
         - protocols
-  - git-revision-date
   - git-revision-date-localized:
       locale: en
       fallback_to_build_date: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ plugins:
         - roles
         - components
         - credentials
+        - protocols
   - git-revision-date
   - git-revision-date-localized:
       locale: en
@@ -92,8 +93,13 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Rulebook:
+    - Overview: rulebook/index.md
     - mVRC: rulebook/mVRC-rulebook.md
     - Trust Framework: rulebook/wp2-trust-specifications/deliverable-2.1-trust.md
+  - RFCs:
+    - Overview: horizontal-RFCs/index.md
+    - RFC-01 Credential Issuance Profile: horizontal-RFCs/RFC001.md
+    - RFC-02 Presentation Profile: horizontal-RFCs/RFC002.md
   - Standards: standards.md
   - Glossary: 
     - Glossary: glossary.md

--- a/script/ezglossary_replace.py
+++ b/script/ezglossary_replace.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Replace glossary terms with ezglossary <section:term> link syntax in RFC files.
+
+Also removes Section 3.1 Terminology from each RFC.
+"""
+import re
+import sys
+
+# Terms ordered by descending search-pattern length to prevent partial matches.
+# Each entry: (regex_pattern, replacement, table_replacement)
+# table_replacement has | escaped to \| for use inside markdown table rows.
+TERMS = [
+    # === Full forms with abbreviation in parentheses (longest first) ===
+    (r'\bQualified Electronic Attestation of Attributes \(QEAA\)',
+     '<credentials:Qualified Electronic Attestation of Attributes (QEAA)>',
+     '<credentials:Qualified Electronic Attestation of Attributes (QEAA)>'),
+    (r'\bElectronic Attestation of Attributes \(EAA\)',
+     '<credentials:Electronic Attestation of Attributes (EAA)>',
+     '<credentials:Electronic Attestation of Attributes (EAA)>'),
+    (r'\bPerson Identification Data \(PID\)',
+     '<credentials:Person Identification Data (PID)>',
+     '<credentials:Person Identification Data (PID)>'),
+    (r'\bWallet Unit Attestation \(WUA\)',
+     '<components:Wallet Unit Attestation (WUA)>',
+     '<components:Wallet Unit Attestation (WUA)>'),
+    (r'\bWallet Instance Attestation \(WIA\)',
+     '<components:Wallet Instance Attestation (WIA)>',
+     '<components:Wallet Instance Attestation (WIA)>'),
+    (r'\bPushed Authorisation Request \(PAR\)',
+     '<protocols:Pushed Authorisation Request (PAR)>',
+     '<protocols:Pushed Authorisation Request (PAR)>'),
+
+    # === Multi-word compound terms (longest first) ===
+    # "Wallet Unit Attestation" / "Wallet Instance Attestation" without the abbreviation
+    (r'\bWallet Unit Attestations\b',
+     '<components:Wallet Unit Attestation (WUA)|Wallet Unit Attestations>',
+     r'<components:Wallet Unit Attestation (WUA)\|Wallet Unit Attestations>'),
+    (r'\bWallet Unit Attestation\b',
+     '<components:Wallet Unit Attestation (WUA)|Wallet Unit Attestation>',
+     r'<components:Wallet Unit Attestation (WUA)\|Wallet Unit Attestation>'),
+    (r'\bWallet Instance Attestations\b',
+     '<components:Wallet Instance Attestation (WIA)|Wallet Instance Attestations>',
+     r'<components:Wallet Instance Attestation (WIA)\|Wallet Instance Attestations>'),
+    (r'\bWallet Instance Attestation\b',
+     '<components:Wallet Instance Attestation (WIA)|Wallet Instance Attestation>',
+     r'<components:Wallet Instance Attestation (WIA)\|Wallet Instance Attestation>'),
+
+    # Multi-word role/component terms
+    (r'\bCredential Issuers\b',
+     '<roles:Credential Issuer|Credential Issuers>',
+     r'<roles:Credential Issuer\|Credential Issuers>'),
+    (r'\bCredential Issuer\b',
+     '<roles:Credential Issuer>',
+     '<roles:Credential Issuer>'),
+    (r'\bAuthorisation Servers\b',
+     '<roles:Authorisation Server|Authorisation Servers>',
+     r'<roles:Authorisation Server\|Authorisation Servers>'),
+    (r'\bAuthorisation Server\b',
+     '<roles:Authorisation Server>',
+     '<roles:Authorisation Server>'),
+    (r'\bVerifier Backends\b',
+     '<roles:Verifier Backend|Verifier Backends>',
+     r'<roles:Verifier Backend\|Verifier Backends>'),
+    (r'\bVerifier Backend\b',
+     '<roles:Verifier Backend>',
+     '<roles:Verifier Backend>'),
+    (r'\bRelying Applications\b',
+     '<roles:Relying Application|Relying Applications>',
+     r'<roles:Relying Application\|Relying Applications>'),
+    (r'\bRelying Application\b',
+     '<roles:Relying Application>',
+     '<roles:Relying Application>'),
+    (r'\bWallet Providers\b',
+     '<roles:Wallet Provider|Wallet Providers>',
+     r'<roles:Wallet Provider\|Wallet Providers>'),
+    (r'\bWallet Provider\b',
+     '<roles:Wallet Provider>',
+     '<roles:Wallet Provider>'),
+    (r'\bWallet Solutions\b',
+     '<components:Wallet Solution|Wallet Solutions>',
+     r'<components:Wallet Solution\|Wallet Solutions>'),
+    (r'\bWallet Solution\b',
+     '<components:Wallet Solution>',
+     '<components:Wallet Solution>'),
+    (r'\bEUDI Wallets\b',
+     '<components:EUDI Wallet|EUDI Wallets>',
+     r'<components:EUDI Wallet\|EUDI Wallets>'),
+    (r'\bEUDI Wallet\b',
+     '<components:EUDI Wallet>',
+     '<components:EUDI Wallet>'),
+    (r'\bWallet Units\b',
+     '<components:Wallet Unit|Wallet Units>',
+     r'<components:Wallet Unit\|Wallet Units>'),
+    (r'\bWallet Unit\b',
+     '<components:Wallet Unit>',
+     '<components:Wallet Unit>'),
+    (r'\bWallet Instances\b',
+     '<components:Wallet Instance|Wallet Instances>',
+     r'<components:Wallet Instance\|Wallet Instances>'),
+    (r'\bWallet Instance\b',
+     '<components:Wallet Instance>',
+     '<components:Wallet Instance>'),
+
+    # Multi-word protocol/credential terms
+    (r'\bSelective Disclosure\b',
+     '<credentials:Selective Disclosure>',
+     '<credentials:Selective Disclosure>'),
+    (r'\bCredential Offers\b',
+     '<protocols:Credential Offer|Credential Offers>',
+     r'<protocols:Credential Offer\|Credential Offers>'),
+    (r'\bCredential Offer\b',
+     '<protocols:Credential Offer>',
+     '<protocols:Credential Offer>'),
+    (r'\bRequest Objects\b',
+     '<protocols:Request Object|Request Objects>',
+     r'<protocols:Request Object\|Request Objects>'),
+    (r'\bRequest Object\b',
+     '<protocols:Request Object>',
+     '<protocols:Request Object>'),
+    (r'\bPresentation Requests\b',
+     '<protocols:Presentation Request|Presentation Requests>',
+     r'<protocols:Presentation Request\|Presentation Requests>'),
+    (r'\bPresentation Request\b',
+     '<protocols:Presentation Request>',
+     '<protocols:Presentation Request>'),
+
+    # Hyphenated protocol terms
+    (r'\bProof-of-possession\b',
+     '<protocols:Proof-of-possession>',
+     '<protocols:Proof-of-possession>'),
+    (r'\bproof-of-possession\b',
+     '<protocols:Proof-of-possession|proof-of-possession>',
+     r'<protocols:Proof-of-possession\|proof-of-possession>'),
+    (r'\bKey binding\b',
+     '<protocols:Key binding>',
+     '<protocols:Key binding>'),
+    (r'\bkey binding\b',
+     '<protocols:Key binding|key binding>',
+     r'<protocols:Key binding\|key binding>'),
+    (r'\bDevice binding\b',
+     '<protocols:Device binding>',
+     '<protocols:Device binding>'),
+    (r'\bdevice binding\b',
+     '<protocols:Device binding|device binding>',
+     r'<protocols:Device binding\|device binding>'),
+
+    (r'\bSessionTranscript\b',
+     '<protocols:SessionTranscript>',
+     '<protocols:SessionTranscript>'),
+    (r'\bDeviceResponse\b',
+     '<protocols:DeviceResponse>',
+     '<protocols:DeviceResponse>'),
+
+    # === Single-word terms ===
+    (r'\bHolders\b',
+     '<roles:Holder|Holders>',
+     r'<roles:Holder\|Holders>'),
+    (r'\bHolder\b',
+     '<roles:Holder>',
+     '<roles:Holder>'),
+    (r'\bVerifiers\b',
+     '<roles:Verifier|Verifiers>',
+     r'<roles:Verifier\|Verifiers>'),
+    (r'\bVerifier\b',
+     '<roles:Verifier>',
+     '<roles:Verifier>'),
+    (r'\bDPoP\b',
+     '<protocols:DPoP>',
+     '<protocols:DPoP>'),
+    (r'\bPKCE\b',
+     '<protocols:PKCE>',
+     '<protocols:PKCE>'),
+    (r'\bWUAs?\b',
+     '<components:Wallet Unit Attestation (WUA)|WUA>',
+     r'<components:Wallet Unit Attestation (WUA)\|WUA>'),
+    (r'\bWIAs?\b',
+     '<components:Wallet Instance Attestation (WIA)|WIA>',
+     r'<components:Wallet Instance Attestation (WIA)\|WIA>'),
+
+    # Nonce — only standalone, not inside c_nonce or identifiers
+    (r'\bNonces\b',
+     '<protocols:Nonce|Nonces>',
+     r'<protocols:Nonce\|Nonces>'),
+    (r'(?<![_`])\bNonce\b(?![_`])',
+     '<protocols:Nonce>',
+     '<protocols:Nonce>'),
+    (r'\bnonces\b',
+     '<protocols:Nonce|nonces>',
+     r'<protocols:Nonce\|nonces>'),
+    (r'(?<![_`c])\bnonce\b(?![_`s])',
+     '<protocols:Nonce|nonce>',
+     r'<protocols:Nonce\|nonce>'),
+
+    # Namespace
+    (r'\bNamespaces\b',
+     '<credentials:Namespace|Namespaces>',
+     r'<credentials:Namespace\|Namespaces>'),
+    (r'\bNamespace\b',
+     '<credentials:Namespace>',
+     '<credentials:Namespace>'),
+    (r'\bnamespaces\b',
+     '<credentials:Namespace|namespaces>',
+     r'<credentials:Namespace\|namespaces>'),
+    (r'\bnamespace\b',
+     '<credentials:Namespace|namespace>',
+     r'<credentials:Namespace\|namespace>'),
+]
+
+
+def replace_outside_protected(text, pattern, replacement):
+    """Apply regex replacement only outside <...> tags and `...` inline code."""
+    # Split on: angle-bracket tags (ezglossary links, HTML) and backtick inline code
+    segments = re.split(r'(<[^>]+>|`[^`]+`|\[[^\]]*\]\([^)]*\))', text)
+    for i, seg in enumerate(segments):
+        # Only process unprotected segments (not tags, code, or links)
+        if not (seg.startswith('<') or seg.startswith('`') or seg.startswith('[')):
+            segments[i] = re.sub(pattern, replacement, seg)
+    return ''.join(segments)
+
+
+def is_heading(line):
+    """Lines starting with # are headings."""
+    return line.lstrip().startswith('#')
+
+
+def is_toc_link(line):
+    """ToC entries like '- [text](#anchor)' or '  - [text](#anchor)'."""
+    return bool(re.match(r'\s*-\s*\[.*\]\(#', line))
+
+
+def is_separator(line):
+    return line.strip() == '---'
+
+
+def is_table_sep(line):
+    """Table header separator row: | --- | --- |"""
+    return bool(re.match(r'\s*\|[\s\-:|]+\|\s*$', line))
+
+
+def is_table_row(line):
+    s = line.strip()
+    return s.startswith('|') and s.endswith('|')
+
+
+def process_file(filepath):
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    lines = content.split('\n')
+    result = []
+    in_code_block = False
+    in_references = False
+    skip_terminology = False  # True when inside Section 3.1 Terminology
+
+    for line in lines:
+        # --- Track fenced code blocks ---
+        stripped = line.strip()
+        if stripped.startswith('```'):
+            in_code_block = not in_code_block
+            result.append(line)
+            continue
+        if in_code_block:
+            result.append(line)
+            continue
+
+        # --- Detect and remove Section 3.1 Terminology ---
+        if re.match(r'^###\s+\*\*3\.1\s+Terminology\*\*', stripped):
+            skip_terminology = True
+            continue
+        if skip_terminology:
+            # Stop skipping at the next --- separator or ## heading
+            if is_separator(line) or re.match(r'^##\s', stripped):
+                skip_terminology = False
+                result.append(line)
+            # Otherwise skip the line (paragraph text, blank lines)
+            continue
+
+        # --- Detect References section (no replacements after this) ---
+        if re.match(r'^##\s.*\bReferences\b', stripped):
+            in_references = True
+        if in_references:
+            result.append(line)
+            continue
+
+        # --- Skip heading lines ---
+        if is_heading(line):
+            result.append(line)
+            continue
+
+        # --- Skip ToC anchor links ---
+        if is_toc_link(line):
+            result.append(line)
+            continue
+
+        # --- Skip separator lines and table-header separators ---
+        if is_separator(line) or is_table_sep(line):
+            result.append(line)
+            continue
+
+        # --- Apply term replacements ---
+        is_tbl = is_table_row(line)
+        for pattern, repl, table_repl in TERMS:
+            r = table_repl if is_tbl else repl
+            line = replace_outside_protected(line, pattern, r)
+
+        result.append(line)
+
+    with open(filepath, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(result))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Usage: python ezglossary_replace.py <file1.md> [file2.md ...]")
+        sys.exit(1)
+    for fp in sys.argv[1:]:
+        print(f"Processing {fp} ...")
+        process_file(fp)
+        print(f"  Done: {fp}")


### PR DESCRIPTION
- Introduced RFC-01: Credential Issuance Profile, detailing the baseline for issuing Verifiable Credentials, including roles, protocol overview, and normative requirements.
- Introduced RFC-02: Presentation Profile, outlining the conformance profile for credential presentation and verification, including roles, protocol overview, and baseline features for interoperability.