### PR TITLE
Add new categories of terms in glossary configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,8 +80,12 @@ plugins:
       sections:
         - roles
         - components
+        - artifacts
         - credentials
         - protocols
+        - processes
+        - formats
+        - data-elements
   - git-revision-date-localized:
       locale: en
       fallback_to_build_date: true


### PR DESCRIPTION
This PR aims to add the new categories of terms introduced in #113 to the configuration of `mkdocs` -> `ezglossary`, as they are not properly rendered otherwise.