### PR TITLE
Add Mkdocs support for Admonitions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,8 @@ markdown_extensions:
   - sane_lists
   - tables
   - def_list
+  - admonition
+  - pymdownx.details
   - pymdownx.highlight:
       use_pygments: true
   - pymdownx.superfences:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ plugins:
         - 'rulebook/wp2-trust-specifications/references/**'
         - 'rulebook/wp2-trust-specifications/requirements/**'
         - 'rulebook/wp2-trust-specifications/topics/**'
+        - 'rulebook/wp2-trust-specifications/docs/topics/**'
   - include-markdown:
       comments: true
   - search


### PR DESCRIPTION
This PR adds support to [Admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) by implementing the related Mkdocs extension.