### PR TITLE
Update DTC rulebook with NextCloud review comments and GitHub issues

### DIFF
--- a/docs/rulebook/wp3/dtc-rulebook.md
+++ b/docs/rulebook/wp3/dtc-rulebook.md
@@ -82,7 +82,7 @@ The objective is to preserve a single interoperable DTC representation that is:
 | DTC_AE_04 | APTITUDE DTC SHALL preserve ICAO LDS semantics, including e.g. EF.DG1, EF.DG2, EF.DG14, EF.SOD.|
 | DTC_AE_05 | APTITUDE DTC SHALL preserve the ISO/IEC 23220-4 PhotoID profile. |
 | DTC_AE_06 | APTITUDE DTC SHALL adopt open, standard-based encoding to maximize interoperability and avoid vendor lock-in. |
-| DTC_AE_07 | APTITUDE DTC SHALL support a trust architecture that enables verification via ICAO CSCA/DS and EUDI Wallet / eIDAS trust anchors. |
+| DTC_AE_07 | APTITUDE DTC SHALL support a trust architecture that enables verification via ICAO CSCA/DS and EUDI Wallet/eIDAS trust anchors. |
 | DTC_AE_08 | APTITUDE DTC SHALL preserve the cryptographic binding between the virtual credential and the Wallet Secure Component across issuance, storage, presentation, and verification. |
 | DTC_AE_09 | APTITUDE DTC SHALL support selective disclosure and minimisation as a layer on top of the single PhotoID credential format, not by introducing a second credential format. |
 

--- a/docs/rulebook/wp3/dtc-rulebook.md
+++ b/docs/rulebook/wp3/dtc-rulebook.md
@@ -452,7 +452,7 @@ CSCA root certificates MAY also be obtained from the ICAO PKD by any Relying Par
 
 ### 6.1 Reasons for revocation 
 
-Reasons for revocation or invalidation may include, but are not limited to, loss or compromise of the Wallet Unit, revocation or replacement of the corresponding physical eMRTD, compromise of the APTITUDE DTC issuer certificate or issuer trust chain, incorrect or fraudulently issued APTITUDE DTC data, or invalidation of the applicable ICAO certificate chain.
+Reasons for revocation or invalidation may include, but are not limited to, device loss or compromise of the Wallet Unit, revocation or replacement of the corresponding physical eMRTD, compromise of the APTITUDE DTC issuer certificate or issuer trust chain, incorrect or fraudulently issued APTITUDE DTC data, or invalidation of the applicable ICAO certificate chain.
 
 ### 6.2 APTITUDE DTC revocation
 

--- a/docs/rulebook/wp3/dtc-rulebook.md
+++ b/docs/rulebook/wp3/dtc-rulebook.md
@@ -450,7 +450,7 @@ CSCA root certificates MAY also be obtained from the ICAO PKD by any Relying Par
 
 ## 6 Revocation
 
-### 6.1 Reasons for revocation 
+### 6.1 Reasons for revocation
 
 Reasons for revocation or invalidation may include, but are not limited to, device loss or compromise of the Wallet Unit, revocation or replacement of the corresponding physical eMRTD, compromise of the APTITUDE DTC issuer certificate or issuer trust chain, incorrect or fraudulently issued APTITUDE DTC data, or invalidation of the applicable ICAO certificate chain.
 

--- a/docs/rulebook/wp3/dtc-rulebook.md
+++ b/docs/rulebook/wp3/dtc-rulebook.md
@@ -12,10 +12,10 @@ Author(s):
 |---------|------------|------------|
 | 0.1 | 11-02-2026 | First draft version - Filled par 1.1 |
 | 0.2 | 27-05-2026 | Updated based on design assumptions from D3.1  |
-| 0.3 | 29-05-2026 | addition of schema and mapping |
-| 0.4 | 12-06-2026 | synchronization with PhotoID specification in [ISO/IEC 23220-4] |
-| 0.5 | 01-07-2026 | align clause 2 and 3 with rulebook template, biblopgraphy added, trust model and revocation added |
-| 0.6 | 08-07-2026 | use cases added in clause 4, editorial changes |
+| 0.3 | 29-05-2026 | Addition of schema and mapping |
+| 0.4 | 12-06-2026 | Synchronization with PhotoID specification in [ISO/IEC 23220-4] |
+| 0.5 | 01-07-2026 | Align clause 2 and 3 with rulebook template, bibliography added, trust model and revocation added |
+| 0.6 | 08-07-2026 | Use cases added in clause 4, editorial changes |
 
 Feedback:
 
@@ -33,7 +33,7 @@ This Attestation Rulebook defines the Digital Travel Credential (DTC) as an elec
 
 The primary objective of the DTC is to facilitate secure and privacy-preserving identity verification and travel document validation at border crossing points and during travel. The DTC is designed to complement existing physical travel documents (e.g. passports, visas) by providing a digital equivalent that supports selective disclosure, offline and online presentation and strong cryptographic verification.
 
-Within the Aptitude context, the target model is the ICAO DTC Type 2, bound to a physical eMRTD and derived using mechanisms aligned with European regulations and ICAO guidelines. Type 2 is therefore considered the primary and preferred implementation model. However, the framework may also support ICAO DTC Type 1 where it is based on an LDS (Logical Data Structure) signed by the official passport authority. In such cases, the DTC is encapsulated within an attestation stored in the EUDI Wallet, ensuring that it remains cryptographically linked to a physical component and provides sufficient assurance for border control use cases.
+Within the APTITUDE context, the target model is the ICAO DTC Type 2, bound to a physical eMRTD and derived using mechanisms aligned with European regulations and ICAO guidelines. Type 2 is therefore considered the primary and preferred implementation model. However, the framework may also support ICAO DTC Type 1 where it is based on an LDS (Logical Data Structure) signed by the official passport authority. In such cases, the DTC is encapsulated within an attestation stored in the EUDI Wallet, ensuring that it remains cryptographically linked to a physical component and provides sufficient assurance for border control use cases.
 
 This rulebook specifies:
 
@@ -49,7 +49,7 @@ This rulebook specifies:
 * Chapter 4, which specifies attestation usage.
 * Chapter 5, which specifies trust anchors.
 * Chapter 6, which specifies revocation.
-* Chapter 7, which specificies compliance.
+* Chapter 7, which specifies compliance.
 
 ### 1.3 Key words
 
@@ -57,7 +57,7 @@ This document uses the capitalised keywords 'SHALL', 'SHOULD' and 'MAY' as speci
 
 ### 1.4 Terminology
 
-Terminologies and definitions within Aptitude project are listed in [APTITUDE Glossary](../glossary.md)
+Terminology and definitions within APTITUDE project are listed in [APTITUDE Glossary](../glossary.md)
 
 ## 2 Attestation attributes and metadata
 
@@ -79,11 +79,12 @@ The objective is to preserve a single interoperable DTC representation that is:
 | DTC_AE_01 | APTITUDE DTC SHALL use ISO/IEC 23220-4 PhotoID as the sole credential format. |
 | DTC_AE_02 | APTITUDE DTC SHALL use ISO/IEC 18013-5 mdoc-cbor encoding for the PhotoID credential. |
 | DTC_AE_03 | APTITUDE DTC SHALL support NFC engagement for proximity presentation and BLE data retrieval for Android and iOS. |
-| DTC_AE_04 | APTITUDE DTC SHALL preserve ICAO LDS semantics, including e.g. EF.DG1, EF.DG2, DG14, EF.SOD, and the PhotoID profile. |
-| DTC_AE_05 | APTITUDE DTC SHALL adopt open, standard-based encoding to maximize interoperability and avoid vendor lock-in. |
-| DTC_AE_06 | APTITUDE DTC SHALL support a trust architecture that enables verification via ICAO CSCA/DS and EUDI Wallet / eIDAS trust anchors. |
-| DTC_AE_07 | APTITUDE DTC SHALL preserve the cryptographic binding between the virtual credential and the Wallet Secure Component across issuance, storage, presentation, and verification. |
-| DTC_AE_08 | APTITUDE DTC SHALL support selective disclosure and minimisation as a layer on top of the single PhotoID credential format, not by introducing a second credential format. |
+| DTC_AE_04 | APTITUDE DTC SHALL preserve ICAO LDS semantics, including e.g. EF.DG1, EF.DG2, DG14, EF.SOD.|
+| DTC_AE_05 | APTITUDE DTC SHALL preserve the ISO/IEC 23220-4 PhotoID profile. |
+| DTC_AE_06 | APTITUDE DTC SHALL adopt open, standard-based encoding to maximize interoperability and avoid vendor lock-in. |
+| DTC_AE_07 | APTITUDE DTC SHALL support a trust architecture that enables verification via ICAO CSCA/DS and EUDI Wallet / eIDAS trust anchors. |
+| DTC_AE_08 | APTITUDE DTC SHALL preserve the cryptographic binding between the virtual credential and the Wallet Secure Component across issuance, storage, presentation, and verification. |
+| DTC_AE_09 | APTITUDE DTC SHALL support selective disclosure and minimisation as a layer on top of the single PhotoID credential format, not by introducing a second credential format. |
 
 #### Table 2 — Requirements on issuing
 
@@ -98,7 +99,7 @@ The objective is to preserve a single interoperable DTC representation that is:
 
 | Index | Requirement specification |
 | --- | --- |
-| DTC_DM_01 | The APTITUDE DTC SHALL contain DG1, DG2, DG14, SOD  as from the physical eMRTD passport and MAY contain other data groups allowed by ICAO DTC-VC specifications, as long as they are also present in the corresponding physical eMRTD |
+| DTC_DM_01 | The APTITUDE DTC SHALL contain DG1, DG2, DG14, SOD  as derived from the physical eMRTD passport and MAY contain other data groups allowed by ICAO DTC-VC specifications, as long as they are also present in the corresponding physical eMRTD. |
 | DTC_DM_02 | APTITUDE DTC MAY contain additional attributes beyond the derived eMRTD dataset |
 | DTC_DM_03 | The data model SHALL support Selective Disclosure, allowing the traveller to share only the strictly necessary attributes (e.g., only DG2 for biometric match) with Relying Parties. |
 
@@ -117,19 +118,19 @@ The objective is to preserve a single interoperable DTC representation that is:
 | ``dg2`` | according to [ISO/IEC 23220-4] | ... |
 | ``dg14`` | according to [ISO/IEC 23220-4] | ... |
 
-### 2.3 Optional attributes
+### 2.3 Optional and conditional attributes
 
 | **Identifier** | **Description** | **Example** |
 | --- | --- | --- |
 | ``family_name_viz`` | according to [ISO/IEC 23220-4] | HARDT |
 | ``given_name_viz`` | according to [ISO/IEC 23220-4] | GIOVANNI |
-| ``enrolment_portrait_image`` | according to [ISO/IEC 23220-4] | ...  |
+| ``enrolment_portrait_image`` | according to [ISO/IEC 23220-4] <br><br> portrait image captured during enrolment of the PhotoID holder| ...  |
 | ``age_in_years`` | according to [ISO/IEC 23220-4] | 28  |
 | ``age_birth_year`` | according to [ISO/IEC 23220-4] | 1998  |
 | ``portrait_capture_date`` | according to [ISO/IEC 23220-4] | 20-04-2023 |
 | ``birthplace`` | according to [ISO/IEC 23220-4] | Italy, Trento |
 | ``name_at_birth`` | according to [ISO/IEC 23220-4] | Nick |
-| ``resident_address`` | according to [ISO/IEC 23220-4] | Sommarive, 18 |
+| ``resident_address`` | according to [ISO/IEC 23220-4] | Roma, 45 |
 | ``resident_city`` | according to [ISO/IEC 23220-4] | Trento |
 | ``resident_postal_code`` | according to [ISO/IEC 23220-4] | 38122 |
 | ``resident_country`` | according to [ISO/IEC 23220-4] | IT |
@@ -141,8 +142,8 @@ The objective is to preserve a single interoperable DTC representation that is:
 | ``birth_country`` |  according to [ISO/IEC 23220-4] | IT |
 | ``birth_state`` |  according to [ISO/IEC 23220-4] | Trento |
 | ``birth_city`` |  according to [ISO/IEC 23220-4] | Trento |
-| ``resident_street`` | according to [ISO/IEC 23220-4] | Sommarive |
-| ``resident_house_number`` | according to [ISO/IEC 23220-4] | 18 |
+| ``resident_street`` | according to [ISO/IEC 23220-4] | Roma |
+| ``resident_house_number`` | according to [ISO/IEC 23220-4] | 45 |
 | ``resident_state`` | according to [ISO/IEC 23220-4] | IT |
 | ``dg3`` | according to [ISO/IEC 23220-4] | ... |
 | ``dg4`` | according to [ISO/IEC 23220-4] | ... |
@@ -155,7 +156,7 @@ The objective is to preserve a single interoperable DTC representation that is:
 | ``dg11`` | according to [ISO/IEC 23220-4] | ... |
 | ``dg12`` | according to [ISO/IEC 23220-4] | ... |
 | ``dg13`` | according to [ISO/IEC 23220-4] | ... |
-| ``dg15`` | according to [ISO/IEC 23220-4] | ... |
+| ``dg15`` | according to [ISO/IEC 23220-4] <br><br>*Condition:* mandatory if available in the corresponding physical eMRTD | ... |
 | ``dg16`` | according to [ISO/IEC 23220-4] | ... |
 
 ### 2.4 Mandatory metadata
@@ -202,16 +203,16 @@ The namespace for **ICAO PhotoID data elements** defined in clause 3.1.4 SHALL b
 
 *Note:* The namespace identifier is ``org.iso.23220.datagroups.1``.
 
-Member States MAY add additional namespaces under their responsibility. The namespace for **Member State specific data elements** SHALL be as specified in clauses C.1.2 of [ISO/IEC 23220-4].
+Member States MAY add additional namespaces under their responsibility. The namespace for **Member State specific data elements** SHALL be as specified in clause C.1.2 of [ISO/IEC 23220-4].
 
 *Note:* The domestic namespace of the European Union is ``org.iso.23220.photoid.EU.1`` with number 1 indicating the version of this namespace and excluding the version number of photoid namespace.
 
-The next section define general and specific data elements of the PhotoID.
+The next section defines general and specific data elements of the PhotoID.
 These elements are given in tables of three columns:
 
 * The "Identifier" column is the reference of the data element specified in clause 2.
 * The “data element identifier according to [ISO/IEC 23220-4]” column gives the mapping of the data element to the data element identifier specified in [ISO/IEC 23220-4].
-* The "Presence" column indicates whether the presence of the element on an APTITUDE DTC is mandatory (M), optional (O) or conditional (C). A mandatory data elemement SHALL be present in an APTITUTED DTC whereas an optional data element MAY be present. If a data element is conditional the respective condition is given in the specification. If the condition is met the data element SHALL be present.
+* The "Presence" column indicates whether the presence of the element on an APTITUDE DTC is mandatory (M), optional (O) or conditional (C). A mandatory data element SHALL be present in an APTITUDE DTC whereas an optional data element MAY be present. If a data element is conditional the respective condition is given in the specification. If the condition is met the data element SHALL be present.
 
 #### 3.1.2 General PhotoID data elements
 
@@ -296,17 +297,33 @@ The ICAO PhotoID data elements of APTITUDE DTC SHALL be as defined in Table 3 an
 | ``dg16`` | ``dg16`` | O |
 | ``sod`` | ``sod`` | M |
 
-#### 3.1.5 Additonal document encryption
+#### 3.1.5 Additional document encryption
 
-If a Relying Party requires document encryption in addition to the session encrption layer, it SHALL encode the document request according to [ISO/IEC 18013-5.2]. The EUDI-Wallet SHALL encrypt the requested data elements acording to [ISO/IEC 18013-5.2].  
+If a Relying Party requires document encryption in addition to the session encryption layer, it SHALL encode the document request according to [ISO/IEC 18013-5.2]. The EUDI Wallet SHALL encrypt the requested data elements according to [ISO/IEC 18013-5.2].  
+
+#### 3.1.6 Mapping from PhotoID to ICAO-based encoding
+
+The following table maps selected PhotoID data elements to the corresponding ICAO eMRTD LDS data, either as carried ICAO data groups or as values obtained or computed from those data groups.
+
+|org.iso.23220.1 | org.iso.23220.datagroups.1 |eMRTD|
+|----                   | ----------          |---|
+| | dg1 | EF.DG1 |
+| | dg2 | EF.DG2 |
+| | dg14 | EF.DG14 |
+| | sod | EF.SOD |
+| birth_date | | EF.DG1 |
+| age_over_18 | | EF.DG1 |
+| age_over_18 | | EF.DG2 |
 
 ## 4 Attestation Usage
 
-This section briefly describes how attestions of type *APTITUDE DTC* are intended to be used. All requested attributes are examples and the request may include other data elemenst as given in the use cases.
+This section briefly describes how attestations of type *APTITUDE DTC* are intended to be used. All requested attributes are examples and the request may include other data elements as given in the use cases.
 
 ### 4.1 Airline-mediated remote pre‑clearance (airline registers passenger with Border Control)
 
 **Context:** Passenger who booked an international flight checks in remotely (app or website) and the airline must register the passenger with the Member State Border Authority for pre‑clearance (advance checks / pre‑assessment), see [APTITUDE-D3.1].
+
+This use case is without prejudice to applicable Advance Passenger Information (API) obligations, including [EU-API-2025-12] where applicable. APTITUDE DTC data MAY support or complement the carrier’s API submission, subject to Member State implementation.
 
 [//]: # (See D3.1: Stock‑Taking, Analysis and Specifications — pilot use cases and advance submission, 27‑02‑2026.)
 
@@ -320,11 +337,11 @@ APTITUDE DTC:
 
 * General PhotoID data elements: ``family_name``, ``given_name``, ``birth_date``, ``issue_date``, ``expiry_date``, ``issuing_authority``, ``document_number``
 * Special PhotoID data elements: ``travel_document_mrz``
-* ICAO PhotoID data elements: ``dg1``, ``dg2``, ``dg14``, ``sod``
+* ICAO PhotoID data elements: ``version``, ``dg1``, ``dg2``, ``dg14``, ``sod``, and ``dg15`` where available and required by the Border Authority.
 
 [//]: # (These are the rulebook §2 mandatory/priority attributes; D3.1 does not define a stricter per‑scenario list.)
 
-**Post‑processing:** the airline backend (or its designated submission service) MUST verify holder proof/possession assertions from the wallet (if applicable), validate the DTC signature and certificate chain and check revocation/status using the applicable trust anchors (CSCA/DS and/or EU trust lists). The airline then packages the verified data for server‑to‑server submission to the Border Authority (mapping of DTC elements to the receiving envelope is a Member State decision; legacy readers may require extraction/encapsulation into ICAO DTCContentInfo/ASN.1). The Border Authority performs full verification (passive authentication: SOD/DG hash checks, PKI chain, revocation/status) and ingests dg1, dg2, dg14 and sod for registration and risk checks.
+**Post‑processing:** the airline backend (or its designated submission service) MUST verify holder proof/possession assertions from the wallet (if applicable), validate the DTC signature and certificate chain and check revocation/status using the applicable trust anchors (CSCA/DS and/or EU trust lists). The airline then packages the verified data for server‑to‑server submission to the Border Authority (mapping of DTC elements to the receiving envelope is a Member State decision; legacy readers may require extraction/encapsulation into ICAO DTCContentInfo/ASN.1). The Border Authority performs full verification (passive authentication: SOD/DG hash checks, PKI chain, revocation/status) and ingests the required ICAO PhotoID data elements for registration and risk checks. Where supported by the Member State implementation, the verification outcome MAY be returned to the traveller through the carrier or designated submission channel.
 
 [//]: # (D3.1 describes the pre‑assessment use case and the need for an interoperable transmission protocol; it does not mandate a single packaging mechanism — implementers must document the chosen transport and envelope.)
 
@@ -342,12 +359,13 @@ APTITUDE DTC:
 
 * General PhotoID data elements: ``family_name``, ``given_name``, ``birth_date``, ``issue_date``, ``expiry_date``, ``issuing_authority``, ``document_number``, ``age_over_18``, ``portrait``
 * Special PhotoID data elements: ``travel_document_mrz``
+* ICAO PhotoID data elements: ``version``, ``dg1``, ``dg2``, ``dg14``, ``sod``.
 
-The request may include ``age_over_18`` or ``portrait`` if required by the Member State for biometric pre‑matching.
+The request may include ``age_over_18`` where required for age-based verification or ``portrait`` if required by the Member State for biometric pre‑matching.
 
 [//]: # (These follow the rulebook §2 attribute set; D3.1 does not specify per‑scenario attribute subsets.)
 
-**Post‑processing:** the receiving Border backend validates the wallet presentation (proof of possession), verifies the DTC signature and PKI chain and checks revocation/status. Verification outcome drives pre‑assessment workflows (EES/ETIAS/API/SIS/SLTD queries). If selective disclosure was used, the backend MUST verify integrity (for example by checking SOD/DG hashes or using a documented bridging mechanism) before accepting partial disclosures.
+**Post-processing:** the receiving Border backend validates the wallet presentation, including any proof of possession, verifies the DTC signature and applicable trust chain, and checks revocation/status. Verification outcome drives pre-assessment workflows (EES/ETIAS/API/SIS/SLTD queries). If selective disclosure was used, the backend MUST verify the integrity and authenticity of the disclosed PhotoID data elements using the cryptographic mechanism of the selected data format. Where ICAO PhotoID data elements are disclosed, the backend SHALL additionally perform ICAO passive authentication by validating the SOD, checking the disclosed DG hashes, and verifying the applicable ICAO trust chain. Where supported by the Member State implementation, the backend MAY return a status or operational instruction to the traveller, such as confirmation of successful pre-registration, required corrective action, or guidance on the applicable border-control process.
 
 [//]: # (D3.1 highlights the selective‑disclosure vs LDS integrity tension but does not prescribe a single resolution, so the Member State policy must define acceptance criteria.)
 
@@ -363,13 +381,13 @@ APTITUDE DTC
 
 * General PhotoID data elements: ``family_name``, ``given_name``, ``birth_date``, ``issue_date``, ``expiry_date``, ``issuing_authority``, ``age_over_18``, ``portrait``
 * Special PhotoID data elements: ``person_id``
-* ICAO PhotoID data elements: ``dg1``, ``dg2``, ``dg14``, ``sod``, ``version``
+* ICAO PhotoID data elements: ``version``, ``dg1``, ``dg2``, ``dg14``, ``sod``, and ``dg15`` where available and required for Active Authentication.
 
-Priority attributes for on‑site verification and biometric matching are ``dg2`` (portrait), ``dg1`` (biographic / MRZ), ``sod``, ``dg14`` if the Member State uses it for inspection). Attributes ``version``, ``person_id``, ``expiry_date``, ``issuing_authority``, ``age_over_18`` and ``portrait`` are optional depending on the check (age verification, biometric fallback).
+Priority attributes for on‑site verification and biometric matching are ``dg2`` (portrait), ``dg1`` (biographic / MRZ), ``sod``, ``dg14`` if the Member State uses it for inspection. Attributes ``version``, ``person_id``, ``expiry_date``, ``issuing_authority``, ``age_over_18`` and ``portrait`` are optional depending on the check (age verification, biometric fallback).
 
 [//]: # (Chosen attributes reflect rulebook §2 priorities and D3.1 emphasis on DG2/SOD for biometric anchoring.)
 
-**Post‑processing:** the proximity reader / e‑gate performs device engagement, retrieves the DTC, validates SOD / passive authentication (signature verification and PKI chain to CSCA/PKD), checks revocation/status and carries out biometric 1:1 matching of the live capture to dg2. The gate/backend then forwards verification results and any required DGs (dg1/dg2/sod and selected metadata) to backend systems for database checks (EES, SIS, SLTD) and final decision. The pilot MUST state whether translation to ASN.1 DTCContentInfo is required for legacy inspection systems; D3.1 signals this requirement as a possible necessity but does not fix the mapping responsibilities.
+**Post‑processing:** the proximity reader / e‑gate performs device engagement, retrieves the DTC, validates SOD / passive authentication (signature verification and PKI chain to CSCA/PKD), checks revocation/status and carries out biometric 1:1 matching of the live capture to dg2. The gate/backend then forwards verification results and any required DGs (dg1/dg2/sod and selected metadata) to backend systems for database checks (EES, SIS, SLTD) and final decision. The pilot MUST state whether translation to ASN.1 DTCContentInfo is required for legacy inspection systems; D3.1 signals this requirement as a possible necessity but does not fix the mapping responsibilities. The reader, eGate or officer interface presents the applicable operational outcome according to the Member State border-control process.
 
 ### 4.4 Cross‑jurisdiction proximity presentation (EU traveller arriving outside Schengen — optional)
 
@@ -385,14 +403,15 @@ APTITUDE DTC
 
 * General PhotoID data elements: ``family_name``, ``given_name``, ``birth_date``, ``issue_date``, ``expiry_date``, ``issuing_authority``, ``document_number``, ``portrait``
 * Special PhotoID data elements: ``travel_document_mrz``
+* ICAO PhotoID data elements: ``version``, ``dg1``, ``dg2``, ``dg14``, ``sod``.
 
 [//]: # (D3.1 does not define which attributes a receiving non‑EU authority will require; this baseline reflects rulebook §2 mandatory/priority elements typically needed for equivalence to an eMRTD.)
 
-**Post‑processing:** the non‑EU verifier validates the credential using ICAO PKI (CSCA/DS via PKD) and its local acceptance policy. If the receiving system requires ICAO ASN.1 DTCContentInfo, an intermediate gateway or the wallet/traveller router may need to extract dg1/dg2/sod and encapsulate them accordingly; D3.1 documents that such translation and trust alignment are common cross‑jurisdiction issues but does not prescribe which actor must perform the translation. If the verifier cannot validate under available trust anchors, the fallback/acceptance policy is a matter for the receiving authority.
+**Post‑processing:** the non‑EU verifier validates the credential using ICAO PKI (CSCA/DS via PKD) and its local acceptance policy. If the receiving system requires ICAO ASN.1 DTCContentInfo, an intermediate gateway or the wallet/traveller router may need to extract the disclosed ICAO PhotoID data elements and encapsulate them accordingly; D3.1 documents that such translation and trust alignment are common cross‑jurisdiction issues but does not prescribe which actor must perform the translation. If the verifier cannot validate under available trust anchors, the fallback/acceptance policy is a matter for the receiving authority. Where supported by the receiving authority, the verifier MAY return an operational outcome to the traveller according to the applicable local border-control process.
 
 ### 4.5 Booklet-based proximity presentation to legacy eGate (“fallback”)
 
-**Context:** Use casess 4.1 or 4.2 have succeeded such that traveler has been successfully registered. Traveler approaches legacy eGate in order to cross border, with booklet passport.
+**Context:** Use cases 4.1 or 4.2 have succeeded such that traveller has been successfully registered. Traveller approaches legacy eGate in order to cross the border, with booklet passport.
 
 **Flow:**
 
@@ -400,46 +419,56 @@ Option 1: MRZ Scan (traditional)
 
 * Scan the Machine Readable Zone (MRZ) on the travel document.
 * Open the chip.
-* Link the document to the pre-registration data by matching dg1 for example
+* Link the document to the pre-registration data by matching dg1, for example.
 * Perform biometric verification.
 * Active/Chip Authentication
 
 Option 2: Tap&go
 
-* biometric identification.
+* Biometric identification.
 * Link person to the pre-registration data
-* open the chip with dg1 from pre-registration data
+* Open the chip using the document-supported access mechanism, then link the result to the pre-registration data, for example by matching ``dg1`` or the corresponding ``document_number``
 * Active/Chip Authentication
 
 **Requested attributes:**
 
 APTITUDE DTC (see pre-registration use cases 4.1 or 4.2)
 
-* ICAO PhotoID data elements: ``dg1``, ``dg2``, ``dg14``, ``sod``
+* ICAO PhotoID data elements: ``version``, ``dg1``, ``dg2``, ``dg14``, ``sod``, and ``dg15`` where available and required by the inspection system.
+
+**Post-processing:** the legacy eGate or officer interface performs the applicable chip, document and biometric checks, links the live passport read to the pre-registration data, and presents the applicable operational outcome according to the Member State border-control process.
 
 ## 5 Trust Anchors
 
-The APTITUDE DTC is derived from the physical eMRTD LDS data groups and signed by the national issuing authority. The issuing authority SHALL sign the issuer signed data, i.e. the MSO, using a document signer key and certificate under the respective CSCA root certificate according to clause 2.2 in [ICAO-DTC-VC-TR].
+The APTITUDE DTC is derived from data contained in the LDS data groups of the corresponding physical eMRTD and is signed by the national issuing authority. The issuing authority SHALL sign the issuer signed data, i.e. the Mobile Security Object (MSO), using a DTC signer key and certificate under the respective CSCA root certificate, compliant with clause 2.2 in [ICAO-DTC-VC-TR].
 
 *Note:* According to [ICAO-DTC-VC-TR], the DTC signer certificate includes a dedicated OID in the extendedKeyUsage extension, i.e. ``2.23.136.1.1.12.1``.
 
-It is recommended to make the CSCA root certificates of the EU Member States available to Relying Parties in the EUDI-Wallet ecosytem by a respective EU Trust List, i.e. APTITUDE DTC TL. In addition, it is recommended to make the content of the APTITUDE DTC TL available to Relying Parties outside of the EUDI-Wallet ecosystem by a VICAL according to [ISO/IEC 18013-5].
+It is recommended to make the CSCA root certificates of the EU Member States available to Relying Parties in the EUDI Wallet ecosytem by a respective EU Trust List, i.e. APTITUDE DTC TL. In addition, it is recommended to make the content of the APTITUDE DTC TL available to Relying Parties outside of the EUDI Wallet ecosystem by a VICAL according to [ISO/IEC 18013-5].
 
-CSCA root certificates MAY be also obtained from the ICAO PKD by any Relying Party.
+CSCA root certificates MAY also be obtained from the ICAO PKD by any Relying Party.
 
 ## 6 Revocation
 
+### 6.1 Reasons for revocation 
+
+Reasons for revocation or invalidation may include, but are not limited to, loss or compromise of the Wallet Unit, revocation or replacement of the corresponding physical eMRTD, compromise of the APTITUDE DTC issuer certificate or issuer trust chain, incorrect or fraudulently issued APTITUDE DTC data, or invalidation of the applicable ICAO certificate chain.
+
+### 6.2 APTITUDE DTC revocation
+
 Revocation of the APTITUDE DTC, i.e. the mdoc, SHALL be implemented according to [ISO/IEC 18013-5.2], i.e. MSO revocation information. The issuing authority SHALL provide the respective status list.
 
-Revocation of the linked eMRTD and LDS data given in the ICAO PhotoID data elements remains unchanged.
+If an APTITUDE DTC is marked revoked, a Relying Party SHALL reject the APTITUDE DTC and all received data elements of the various namespaces.
 
-If an APTITUDE DTC is marked revoked, a Relying Party SHALL reject all recieved data elements of the various name spaces. If parts of the data elemnts are encrypted according clause 3.1.5, the Relying Party shall also reject the encrypted data.
+### 6.3 Linked eMRTD revocation
+
+Revocation of the linked eMRTD and LDS data given in the ICAO PhotoID data elements remains unchanged and is governed by the applicable ICAO, eMRTD and national procedures.
 
 ## 7 Compliance
 
-If compliance to ICAO DTC-VC Type 1 is required, a reader may after succsessfull processing the device response and the verification prodecure encapsule the data in the structure given in clause 7.1. The reader SHALL use the option eMRTD bound for DTC-VC encoding. The ICAO based encoding for DTC-VC is defined in [ICAO-DTC-VC-TR] and encoding for DTC-PC is defined in [ICAO-DTC-PC-TR]. The reader SHALL use the option eMRTD bound for DTC-VC encoding.
+If compliance to ICAO DTC-VC Type 1 is required, a reader may after succsessful processing the device response and the verification procedure encapsulate the data in the structure given in clause 7.1. The reader SHALL use the option eMRTD bound for DTC-VC encoding. The ICAO based encoding for DTC-VC is defined in [ICAO-DTC-VC-TR] and encoding for DTC-PC is defined in [ICAO-DTC-PC-TR]. The reader SHALL use the option eMRTD bound for DTC-VC encoding.
 
-*Note:* Option eMRTD bound does not include elemts dtcTBS, dtcSignerInfo, DTCSecurityInfo and DTCOtherInfo.  
+*Note:* Option eMRTD bound does not include elements dtcTBS, dtcSignerInfo, DTCSecurityInfo and DTCOtherInfo.  
 
 ### 7.1 ICAO based encoding
 
@@ -529,18 +558,6 @@ dtcOtherInfos [23] EXPLICIT DTCOtherInfos OPTIONAL,
 }
 ```
 
-### 7.2 Mapping from photoId to ICAO based encoding
-
-|org.iso.23220.photoID.1 | org.iso.23220.datagroups.1 |eMRTD|
-|----                   | ----------          |---|
-| dg1 | | EF.DG1 |
-| dg2 | | EF.DG2 |
-| dg14 | | EF.DG14 |
-| sod| | EF.sod |
-|    |birth_date | EF.DG1 |
-|    |age_over_18 | EF.DG1 |
-|    |portrait | EF.DG2 |
-
 ## 8 References
 
 | **Item Reference** | **Standard name/details**|
@@ -553,3 +570,4 @@ dtcOtherInfos [23] EXPLICIT DTCOtherInfos OPTIONAL,
  | [ICAO-DTC-VC-TR] | ICAO Technical Report, Digital Travel Credentials (DTC) - Virtual Component Data Structure and PKI Mechanisms, Version 1.2, October 2020 |
  | [ICAO-DTC-PC-TR] | ICAO Technical Report, Digital Travel Credentials (DTC) - Physical Component and Protocols, Version 1.1, October 2022 |
  | [APTITUDE-D3.1] | APTITUDE, D3.1: Stock‑Taking, Analysis and Specifications — pilot use cases and advance submission, 27‑02‑2026. |
+ | [EU-API-2025-12] | Regulation (EU) 2025/12 of the European Parliament and of the Council of 19 December 2024 on the collection and transfer of  advance passenger information for enhancing and facilitating external border checks, amending Regulations (EU) 2018/1726 and (EU) 2019/817, and repealing Council Directive 2004/82/EC. |

--- a/docs/rulebook/wp3/dtc-rulebook.md
+++ b/docs/rulebook/wp3/dtc-rulebook.md
@@ -427,7 +427,7 @@ Option 2: Tap&go
 
 * Biometric identification.
 * Link person to the pre-registration data
-* Open the chip using the document-supported access mechanism, then link the result to the pre-registration data, for example by matching ``dg1`` or the corresponding ``document_number``
+* Open the chip using the document-supported access mechanism, then link the result to the pre-registration data, for example by matching ``dg1`` or the corresponding ``document_number``.
 * Active/Chip Authentication
 
 **Requested attributes:**

--- a/docs/rulebook/wp3/dtc-rulebook.md
+++ b/docs/rulebook/wp3/dtc-rulebook.md
@@ -79,7 +79,7 @@ The objective is to preserve a single interoperable DTC representation that is:
 | DTC_AE_01 | APTITUDE DTC SHALL use ISO/IEC 23220-4 PhotoID as the sole credential format. |
 | DTC_AE_02 | APTITUDE DTC SHALL use ISO/IEC 18013-5 mdoc-cbor encoding for the PhotoID credential. |
 | DTC_AE_03 | APTITUDE DTC SHALL support NFC engagement for proximity presentation and BLE data retrieval for Android and iOS. |
-| DTC_AE_04 | APTITUDE DTC SHALL preserve ICAO LDS semantics, including e.g. EF.DG1, EF.DG2, DG14, EF.SOD.|
+| DTC_AE_04 | APTITUDE DTC SHALL preserve ICAO LDS semantics, including e.g. EF.DG1, EF.DG2, EF.DG14, EF.SOD.|
 | DTC_AE_05 | APTITUDE DTC SHALL preserve the ISO/IEC 23220-4 PhotoID profile. |
 | DTC_AE_06 | APTITUDE DTC SHALL adopt open, standard-based encoding to maximize interoperability and avoid vendor lock-in. |
 | DTC_AE_07 | APTITUDE DTC SHALL support a trust architecture that enables verification via ICAO CSCA/DS and EUDI Wallet / eIDAS trust anchors. |


### PR DESCRIPTION
This PR addresses review comments from NextCloud (#52 to #71) for the APTITUDE DTC rulebook and resolves issues #222 , #226 , #230 , #235 , #236  and #237 .

## Main changes
- Updated Section 2 to harmonise mandatory, optional and conditional APTITUDE DTC data elements, including the treatment of `dg15` as conditional where available in the corresponding physical eMRTD.
- Clarified `enrolment_portrait_image` in response to issue #230.
- Corrected and clarified the PhotoID to ICAO eMRTD LDS mapping table in response to issue #226.
- Updated Section 4 use cases for consistency of requested ICAO PhotoID data elements and post-processing verification steps.
- Added ICAO PhotoID data elements to cross-jurisdiction proximity presentation where required by ICAO validation or DTCContentInfo extraction, addressing issue #222.
- Included `dg15` where available in relevant use cases, addressing issues #235, #236 and #237.
- Improved wording around selective disclosure, PhotoID integrity verification, ICAO passive authentication, and applicable trust-chain checks.
- Reworked Section 6 Revocation by introducing subsections for revocation reasons, APTITUDE DTC revocation, and linked eMRTD revocation.
- Added or refined operational outcome wording for relevant border-control use cases.
- Fixed editorial issues, typos, terminology consistency.
