### PR TITLE
Pr checks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git check-ignore *)"
-    ]
-  }
-}

--- a/.github/workflows/mkdocs-warnings-pr.yml
+++ b/.github/workflows/mkdocs-warnings-pr.yml
@@ -1,0 +1,54 @@
+name: Mkdocs Warnings (PR)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  mkdocs-warnings:
+    name: Check mkdocs build warnings
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build mkdocs site in strict mode
+        run: |
+          # -s/--strict turns mkdocs warnings into a build failure.
+          # Also convert the warning lines into GitHub annotations.
+          set +e
+          mkdocs build -c -s 2>&1 | tee mkdocs-build.out
+          build_exit=${PIPESTATUS[0]}
+          set -e
+
+          while IFS= read -r line; do
+            if [[ "$line" =~ ^WARNING ]]; then
+              echo "::warning::$line"
+            fi
+          done < mkdocs-build.out
+
+          if [[ $build_exit -ne 0 ]]; then
+            echo "mkdocs build reported warnings in strict mode. See annotations above."
+            exit $build_exit
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .idea/
 *.swp
 *.swo
+.claude/
 
 # Python caches/environments
 __pycache__/


### PR DESCRIPTION
This will add a new check in the pr approval pipeline. 
Should not be enabled before fixing all the existing warnings. 

It can be enabled in the branch protection ruleset.